### PR TITLE
feat(search): 開發搜尋元件的 UI 結構與狀態管理

### DIFF
--- a/app/page.jsx
+++ b/app/page.jsx
@@ -9,10 +9,10 @@ import {
   SERVICE_PROCESS_DATA,
 } from '@/app/lib/placeholder-data';
 
-import SitterSearchForm from './ui/components/SitterSearchForm';
 import TestimonialsSlider from './ui/components/TestimonialsSlider';
 import React from 'react';
 import FaqAccordion from './ui/components/FaqAccordion';
+import SitterSearch from './ui/components/SitterSearch';
 
 // 資料引入
 const servicesData = SERVICES_DATA;
@@ -42,14 +42,7 @@ export default function HomePage() {
                   我們用心為每一位毛孩提供無微不至的照顧服務，讓您的孩子在保母們的呵護下，感受到最真摯的關愛與溫暖
                 </p>
               </div>
-              <div className="position-absolute top-100 start-0 end-0 translate-middle-y px-4 z-2">
-                <div className="row justify-content-md-center">
-                  <div className="col-lg-10">
-                    {/* ✨ 使用拆分出去的 Client Component */}
-                    {/* <SitterSearchForm /> */}
-                  </div>
-                </div>
-              </div>
+              < SitterSearch />
             </div>
           </div>
         </section>

--- a/app/sitters/page.jsx
+++ b/app/sitters/page.jsx
@@ -2,36 +2,185 @@
 
 import style from '@/app/ui/pages/sitters-page.module.scss';
 import Link from 'next/link';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useCallback } from 'react';
+import { useSearchParams, useRouter, usePathname } from 'next/navigation';
 import { StarIcon, MapPinIcon, UserIcon } from '@heroicons/react/16/solid';
 
-export default function SittersPage() {
-  const [sitters, setSitters] = useState([]);
+import SitterSearch from '@/app/ui/components/SitterSearch';
+import { ChevronDownIcon } from '@heroicons/react/20/solid';
 
-  useEffect(() => {
-    async function fetchSitters(page = 1, limit = 8) {
-      try {
-        let url = `http://localhost:3001/users?role=sitter&_page=${page}&_limit=${limit}`;
+const ITEMS_PER_PAGE = 8;
 
-        const res = await fetch(url);
-        const data = await res.json();
-        setSitters(data);
-        return data;
-      } catch (error) {
-        console.log(error);
-      }
+const filterSitters = (sitters, queryParams) => {
+  const service = queryParams.get('service');
+  const petType = queryParams.get('petType');
+  const startDate = queryParams.get('startDate')
+    ? new Date(queryParams.get('startDate'))
+    : null;
+  const endDate = queryParams.get('endDate')
+    ? new Date(queryParams.get('endDate'))
+    : null;
+
+  return sitters.filter((sitter) => {
+    // 條件1：篩選服務類型 (servicesOffered)
+    if (service) {
+      const hasService = sitter.servicesOffered?.some(
+        (s) => s.name === service
+      );
+      if (!hasService) return false;
     }
-    fetchSitters();
+
+    // 條件2：篩選可接受的寵物類型 (acceptedPetTypes)
+    if (petType) {
+      const canAcceptPet = sitter.acceptedPetTypes?.includes(petType);
+      if (!canAcceptPet) return false;
+    }
+
+    // 條件3：篩選日期 (availability)
+    if (startDate && endDate) {
+      // 將星期英文轉換為數字 (0=週日, 1=週一, ...)
+      const dayMap = {
+        sunday: 0,
+        monday: 1,
+        tuesday: 2,
+        wednesday: 3,
+        thursday: 4,
+        friday: 5,
+        saturday: 6,
+      };
+
+      // 獲取使用者選擇日期範圍內的所有星期 (e.g., [1, 2, 3] for Mon, Tue, Wed)
+      const requiredDays = new Set();
+      let currentDate = new Date(startDate);
+      while (currentDate <= endDate) {
+        requiredDays.add(currentDate.getDay());
+        currentDate.setDate(currentDate.getDate() + 1);
+      }
+
+      // 檢查保姆在這些必要的星期中是否都有空
+      let allRequiredDaysAvailable = true;
+      for (const dayIndex of requiredDays) {
+        const dayKey = Object.keys(dayMap).find(
+          (key) => dayMap[key] === dayIndex
+        );
+        if (
+          !sitter.availability ||
+          !sitter.availability[dayKey] ||
+          sitter.availability[dayKey].length === 0
+        ) {
+          allRequiredDaysAvailable = false;
+          break; // 只要有一天不符合，就篩選掉
+        }
+      }
+      if (!allRequiredDaysAvailable) return false;
+    }
+
+    // 所有條件都通過
+    return true;
+  });
+};
+
+export default function SittersPage() {
+  const [allSitters, setAllSitters] = useState([]); // ✨ 儲存所有從後端獲取的（預篩選後）的保姆
+  const [filteredSitters, setFilteredSitters] = useState([]); // ✨ 儲存前端精細篩選後的保姆
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  // ✨ 新增分頁相關的 state
+  const [currentPage, setCurrentPage] = useState(1);
+  const [totalPages, setTotalPages] = useState(0);
+
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams(); // ✨ 用 hook 獲取 URL 查詢參數
+
+  const fetchAndFilterSitters = useCallback(async (currentQuery) => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const queryParams = new URLSearchParams(currentQuery);
+
+      // ✨ 只用 json-server 支援的參數去後端預篩選
+      const apiQuery = new URLSearchParams();
+      if (queryParams.get('address')) {
+        apiQuery.set('address.city', queryParams.get('address'));
+      }
+      // 總是獲取所有 role=sitter 的使用者
+      apiQuery.set('role', 'sitter');
+
+      const url = `http://localhost:3001/users?${apiQuery.toString()}`;
+
+      const res = await fetch(url);
+      if (!res.ok) throw new Error('資料獲取失敗');
+
+      const data = await res.json();
+      setAllSitters(data);
+
+      // ✨ 在前端進行精細篩選
+      const finalFilteredData = filterSitters(data, queryParams);
+      setFilteredSitters(finalFilteredData);
+    } catch (err) {
+      console.error('Failed to process sitters:', err);
+      setError(err.message);
+    } finally {
+      setIsLoading(false);
+    }
   }, []);
+
+  // ✨ 主 useEffect，負責在 searchParams 或 currentPage 改變時獲取資料
+  useEffect(() => {
+    const initialQuery = searchParams.toString();
+    setCurrentPage(1); // 每次新搜尋都重置頁碼
+    fetchAndFilterSitters(initialQuery);
+  }, [searchParams, fetchAndFilterSitters]);
+
+  const handleSearch = (queryString) => {
+    // 更新 URL，這會觸發上面的 useEffect 重新獲取和篩選
+    router.push(`${pathname}?${queryString}`);
+  };
+
+  // --- 分頁邏輯 ---
+  const currentDisplaySitters = filteredSitters.slice(
+    (currentPage - 1) * ITEMS_PER_PAGE,
+    currentPage * ITEMS_PER_PAGE
+  );
+
+  // ✨ 處理分頁變更的函式
+  const handlePageChange = (page) => {
+    if (page < 1 || page > totalPages) return; // 防止超出頁碼範圍
+    setCurrentPage(page);
+    // 將頁面滾動到頂部
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  };
+
+  const renderPagination = () => {
+    if (totalPages <= 1) return null;
+
+    const pages = [];
+    for (let i = 1; i <= totalPages; i++) {
+      pages.push(
+        <li
+          key={i}
+          className={`page-item ${currentPage === i ? 'active' : ''}`}
+        >
+          <button className="page-link" onClick={() => handlePageChange(i)}>
+            {i}
+          </button>
+        </li>
+      );
+    }
+  };
+
   return (
     <>
       <main>
         <section className="bg-gradient-primary-banner mt-lg-21 mt-17">
           <div className={style.searchBanner}>
-            <div className="container pt-11 pb-18 pt-md-16 pb-md-42">
+            <div className="container position-relative pt-11 pb-18 pt-md-16 pb-md-42">
               <h1 className="text-light fs-5 fs-md-3 fs-lg-2 dog-foot-title-md w-fit-content mx-auto">
                 現在就尋找您的寵物保母
               </h1>
+              <SitterSearch onSearch={handleSearch} />
             </div>
           </div>
         </section>
@@ -39,73 +188,150 @@ export default function SittersPage() {
           <div className="container">
             <div className="d-flex justify-content-between align-items-center mb-7 mb-md-11">
               <h2>推薦保母</h2>
-              <div>搜尋區塊-暫</div>
-            </div>
-            <div className="row row-cols-1 row-cols-md-2 row-cols-lg-4 gy-7 gy-md-11 mb-9 mb-lg-13">
-              {sitters.map((sitter) => (
-                <div
-                  className="col d-flex flex-column flex-md-row"
-                  key={sitter.id}
+              <div className="dropdown text-gray-300">
+                <button
+                  href="#"
+                  type="button"
+                  className="custom-dropdown-toggle border-0 bg-gray-1000 w-100 d-flex justify-content-between
+                align-items-center py-4 px-5 rounded-2"
+                  data-bs-toggle="dropdown"
+                  aria-expanded="false"
                 >
-                  <div className="card bg-transparent border-0">
-                    <img
-                      src={sitter.profilePictureUrl}
-                      className={`${style.sitterCardImage} card-img-top object-fit-cover mb-5`}
-                      alt="..."
-                    />
-                    <div className="card-body p-0">
-                      <h5 className="card-title fs-7 text-gray-200 mb-2">
-                        {sitter.name}
-                      </h5>
-                      <div className="d-flex align-items-center mb-md-2 mb-1 flex-wrap">
-                        <StarIcon
-                          className="text-primary me-1"
-                          style={{ width: '16px', height: '16px' }}
-                        />
-                        <span className="fs-10 text-primary me-1">
-                          {sitter.rating.toFixed(1)}
-                        </span>
-                        <span className="fs-10 text-gray-500 me-1">
-                          ({sitter.reviewCount})
-                        </span>
-                        <MapPinIcon
-                          className="me-1 text-gray-500"
-                          style={{ width: '16px', height: '16px' }}
-                        />
-                        <span className="fs-10 text-gray-500 me-1">
-                          {sitter.address?.city},{sitter.address?.district}
-                        </span>
-                        <UserIcon
-                          className="me-1 text-gray-500"
-                          style={{ width: '16px', height: '16px' }}
-                        />
-                        <span className="fs-10 text-gray-500">
-                          ({sitter.totalBookingsCompleted})
-                        </span>
+                  <span className="me-11 me-lg-31 text-gray-300">排序方式</span>
+                  <ChevronDownIcon
+                    className='text-gray-500'
+                    style={{ width: '1.25rem', height: '1.25rem' }}
+                  />
+                </button>
+                <ul className="dropdown-menu py-4 w-100">
+                  <li>
+                    <a
+                      className="dropdown-item py-2 px-4 mb-2 bg-gray-1000-hover"
+                      href="#"
+                    >
+                      {`價錢: 高 => 低`}
+                    </a>
+                  </li>
+                  <li>
+                    <a
+                      className="dropdown-item py-2 px-4 mb-2 bg-gray-1000-hover"
+                      href="#"
+                    >
+                      {`價錢: 低 => 高`}
+                    </a>
+                  </li>
+                  <li>
+                    <a
+                      className="dropdown-item py-2 px-4 mb-2 bg-gray-1000-hover"
+                      href="#"
+                    >
+                      {`距離: 近 => 遠`}
+                    </a>
+                  </li>
+                  <li>
+                    <a
+                      className="dropdown-item py-2 px-4 mb-2 bg-gray-1000-hover"
+                      href="#"
+                    >
+                      {`距離: 遠 => 近`}
+                    </a>
+                  </li>
+                </ul>
+              </div>
+            </div>
+            {isLoading ? (
+              <div className="text-center py-5">
+                <div className="spinner-border text-primary" role="status">
+                  <span className="visually-hidden">載入中...</span>
+                </div>
+              </div>
+            ) : error ? (
+              <div className="alert alert-danger">{error}</div>
+            ) : currentDisplaySitters.length > 0 ? (
+              <div className="row row-cols-1 row-cols-md-2 row-cols-lg-4 gy-7 gy-md-11 mb-9 mb-lg-13">
+                {currentDisplaySitters.map((sitter) => (
+                  <div
+                    className="col d-flex flex-column flex-md-row"
+                    key={sitter.id}
+                  >
+                    <div className="card bg-transparent border-0">
+                      <img
+                        src={sitter.profilePictureUrl}
+                        className={`${style.sitterCardImage} card-img-top object-fit-cover mb-5`}
+                        alt="..."
+                      />
+                      <div className="card-body p-0">
+                        <h5 className="card-title fs-7 text-gray-200 mb-2">
+                          {sitter.name}
+                        </h5>
+                        <div className="d-flex align-items-center mb-md-2 mb-1 flex-wrap">
+                          <StarIcon
+                            className="text-primary me-1"
+                            style={{ width: '16px', height: '16px' }}
+                          />
+                          <span className="fs-10 text-primary me-1">
+                            {sitter.rating.toFixed(1)}
+                          </span>
+                          <span className="fs-10 text-gray-500 me-1">
+                            ({sitter.reviewCount})
+                          </span>
+                          <MapPinIcon
+                            className="me-1 text-gray-500"
+                            style={{ width: '16px', height: '16px' }}
+                          />
+                          <span className="fs-10 text-gray-500 me-1">
+                            {sitter.address?.city},{sitter.address?.district}
+                          </span>
+                          <UserIcon
+                            className="me-1 text-gray-500"
+                            style={{ width: '16px', height: '16px' }}
+                          />
+                          <span className="fs-10 text-gray-500">
+                            ({sitter.totalBookingsCompleted})
+                          </span>
+                        </div>
+                        <p className="card-text fs-10 text-gray-200 mb-2 mb-md-5">
+                          {sitter.bio}
+                        </p>
                       </div>
-                      <p className="card-text fs-10 text-gray-200 mb-2 mb-md-5">
-                        {sitter.bio}
-                      </p>
-                    </div>
-                    <div className="d-flex justify-content-between align-items-center">
-                      <p className="fs-7 fw-bold text-gray-200">
-                        NT$ 550
-                        <span className="ms-1 fs-11 text-gray-500 fw-normal">
-                          每次
-                        </span>
-                      </p>
-                      <Link
-                        href={`/sitters/${sitter.id}`}
-                        className="fs-10 text-primary fw-bold opacity-70-hover transition-base
+                      <div className="d-flex justify-content-between align-items-center">
+                        <p className="fs-7 fw-bold text-gray-200">
+                          NT${' '}
+                          {`${
+                            searchParams.get('service')
+                              ? sitter.servicesOffered
+                                  .map((service) =>
+                                    service.name === searchParams.get('service')
+                                      ? service.price
+                                      : ''
+                                  )
+                                  .join('')
+                              : sitter.servicesOffered[0].price
+                          }`}
+                          <span className="ms-1 fs-11 text-gray-500 fw-normal">
+                            每次
+                          </span>
+                        </p>
+                        <Link
+                          href={`/sitters/${sitter.id}`}
+                          className="fs-10 text-primary fw-bold opacity-70-hover transition-base
                   stretched-link"
-                      >
-                        詳細資料
-                      </Link>
+                        >
+                          詳細資料
+                        </Link>
+                      </div>
                     </div>
                   </div>
-                </div>
-              ))}
-            </div>
+                ))}
+              </div>
+            ) : (
+              <p className="text-center text-muted py-5">
+                找不到符合條件的保姆。
+              </p>
+            )}
+
+            {/* ✨ 渲染分頁元件 */}
+            {totalPages > 1 && renderPagination()}
           </div>
         </section>
       </main>

--- a/app/ui/components/SitterSearch.jsx
+++ b/app/ui/components/SitterSearch.jsx
@@ -1,0 +1,114 @@
+'use client';
+
+import React, { useEffect, useRef } from 'react';
+import { useRouter, usePathname } from 'next/navigation';
+
+import SitterSearchForm from '@/app/ui/components/SitterSearchForm';
+
+import { Modal } from 'bootstrap';
+import styles from './SitterSearch.module.scss';
+
+export default function SitterSearch({ onSearch }) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const isListPage = pathname.startsWith('/sitters');
+  const modalId = 'sitter-search-modal';
+
+  const modalRef = useRef(null);
+  const searchModal = useRef(null);
+
+  useEffect(() => {
+    searchModal.current = new Modal(modalRef.current);
+  }, []);
+
+  const showModal = () => {
+    searchModal.current.show();
+  };
+
+  const hideModal = () => {
+    searchModal.current.hide();
+  };
+
+  const handleSearchSubmit = (searchParams) => {
+    hideModal();
+    // 1. 構建 query string
+    const query = new URLSearchParams();
+
+    if (searchParams.service) query.set('service', searchParams.service);
+    if (searchParams.address) query.set('address.city', searchParams.address);
+    if (searchParams.petType) query.set('petType', searchParams.petType);
+    if (searchParams.dates[0])
+      query.set('startDate', searchParams.dates[0].toISOString().split('T')[0]);
+    if (searchParams.dates[1])
+      query.set('endDate', searchParams.dates[1].toISOString().split('T')[0]);
+
+    const queryString = query.toString();
+
+    // 2. 根據所在頁面執行不同操作
+    if (isListPage) {
+      // 在保母列表頁：呼叫 onSearch 回調函式，將 query string 傳遞給父層
+      if (onSearch) {
+        onSearch(queryString);
+      }
+    } else {
+      // 在首頁：跳轉到保母列表頁，並帶上 query string
+      router.push(`/sitters?${queryString}`);
+    }
+  };
+
+  return (
+    <>
+      <div
+        className="position-absolute top-100 start-0 end-0 translate-middle-y px-4"
+        style={{ zIndex: 10 }}
+      >
+        <div className="row justify-content-md-center">
+          <div className="col-lg-10">
+            {/* Desktop Version */}
+            <div className="d-none d-md-block bg-light rounded-4 shadow-primary">
+              <SitterSearchForm
+                onSearchSubmit={handleSearchSubmit}
+                isModal={false}
+              />
+            </div>
+            {/* Mobile Trigger */}
+            <div className="d-md-none bg-light p-4 rounded-4 d-flex align-items-center shadow-primary">
+              <div
+                className="flex-grow-1 bg-gray-1000 py-4 px-5 rounded-3 me-4"
+                onClick={showModal}
+              >
+                您的需求
+              </div>
+              <button
+                className="btn btn-primary text-light fw-bold px-9"
+                onClick={showModal}
+              >
+                搜尋
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Mobile Modal */}
+      <div
+        ref={modalRef}
+        className={`modal fade`}
+        id={modalId}
+        tabIndex="-1"
+      >
+        <div className="modal-dialog modal-dialog-centered">
+          <div className={`modal-content ${styles.sitterSearchModal}`}>
+            <div className="modal-body pt-0 px-7 pb-9">
+              <SitterSearchForm
+                onSearchSubmit={handleSearchSubmit}
+                isModal={true}
+                hideModal={hideModal}
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/app/ui/components/SitterSearch.module.scss
+++ b/app/ui/components/SitterSearch.module.scss
@@ -1,0 +1,81 @@
+@import '../styles/bootstrap-essentials';
+
+.sitterSearchForm {
+  border-radius: 16px;
+}
+// 服務類型選擇按鈕
+.typeSelectBtn {
+  color: $gray-500;
+  border-width: 0 0 3px 0;
+  border-style: solid;
+  border-color: transparent;
+  transition: color 0.2s ease, border-color 0.2s ease;
+
+  &:hover {
+    color: $primary;
+  }
+
+  &.active {
+    color: $primary;
+    border-bottom-color: $primary;
+  }
+}
+
+// 寵物數量選擇下拉選單
+.petNumDropdown {
+  // 如果需要特別的樣式，例如 dropdown-item 的 hover 背景色
+  :global(.dropdown-item) {
+    cursor: default; // 讓整個項目不可點擊跳轉，只有裡面的按鈕可點
+    &:hover,
+    &:focus {
+      background-color: transparent; // 移除預設的 hover/focus 背景色
+    }
+  }
+}
+
+.searchDropdownMenu {
+  max-height: 150px;
+  overflow-y: scroll;
+  // 如果需要特別的樣式，例如 dropdown-item 的 hover 背景色
+  :global(.dropdown-item) {
+    &:hover,
+    &:focus {
+      background-color: $primary; // 移除預設的 hover/focus 背景色
+      color: $light;
+    }
+  }
+}
+
+// 表單 input 內的 icon 樣式
+.inputIcon {
+  pointer-events: none; // 讓滑鼠可以穿透 icon 點擊到 input
+  z-index: 3;
+  width: 1.25rem;
+  height: 1.25rem;
+}
+
+.datePickerInput {
+  &::placeholder {
+    color: $gray-300;
+    opacity: 1;
+  }
+
+  &::-ms-input-placeholder {
+    color: $gray-300;
+  }
+}
+
+:global(.react-datepicker-popper) {
+  z-index: 1070 !important; // 確保高於 Bootstrap modal 的 z-index (預設 1055)
+}
+
+.sitterSearchModal {
+  border-radius: 16px;
+  box-shadow: 0px 4px 40px 0px #f6844d3d;
+}
+
+// 搜尋時的 Spinner 背景
+.spinnerBg {
+  background-color: rgba(255, 255, 255, 0.7);
+  z-index: 9999;
+}

--- a/app/ui/components/SitterSearchForm.jsx
+++ b/app/ui/components/SitterSearchForm.jsx
@@ -1,133 +1,304 @@
-// app/components/homepage/HeroSearchForm.jsx
+// app/components/search/SitterSearch.jsx
 'use client';
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import Image from 'next/image';
-import Link from 'next/link';
 import {
   ChevronDownIcon,
-  MinusCircleIcon,
-  PlusCircleIcon,
+  MapPinIcon,
+  CalendarDaysIcon,
 } from '@heroicons/react/20/solid';
 
-// 假設這是一個 React 版本的日期選擇器
-// import DatePicker from 'react-datepicker';
-// import 'react-datepicker/dist/react-datepicker.css';
+import DatePicker from 'react-datepicker';
+import 'react-datepicker/dist/react-datepicker.css';
+import { registerLocale } from 'react-datepicker';
+import { zhTW } from 'date-fns/locale/zh-TW';
 
-export default function SitterSearchForm() {
-  const [catCount, setCatCount] = useState(0);
-  const [dogCount, setDogCount] = useState(0);
-  const [selectedArea, setSelectedArea] = useState('地區');
-  // const [startDate, setStartDate] = useState(new Date());
+import { Dropdown } from 'bootstrap';
+import styles from './SitterSearch.module.scss';
 
-  const handlePetCount = (type, operation) => {
-    if (type === 'cat') {
-      setCatCount((prev) => (operation === '+' ? prev + 1 : Math.max(0, prev - 1)));
-    } else {
-      setDogCount((prev) => (operation === '+' ? prev + 1 : Math.max(0, prev - 1)));
-    }
+registerLocale('zh-TW', zhTW);
+
+const serviceTypes = [
+  {
+    key: '遛狗散步',
+    text: '遛狗散步',
+    icon: '/search-page/Dog-icon-primary.svg',
+  },
+  {
+    key: '日間托養',
+    text: '日間托養',
+    icon: '/search-page/Sun-icon-primary.svg',
+  },
+  {
+    key: '外宿寄養',
+    text: '外宿寄養',
+    icon: '/search-page/Home-icon-primary.svg',
+  },
+  {
+    key: '上門餵食',
+    text: '上門餵食',
+    icon: '/search-page/Bone-icon-primary.svg',
+  },
+];
+
+const taiwanCities = [
+  '台北市',
+  '新北市',
+  '桃園市',
+  '台中市',
+  '台南市',
+  '高雄市',
+  '基隆市',
+  '新竹市',
+  '嘉義市',
+  '新竹縣',
+  '苗栗縣',
+  '彰化縣',
+  '南投縣',
+  '雲林縣',
+  '嘉義縣',
+  '屏東縣',
+  '宜蘭縣',
+  '花蓮縣',
+  '台東縣',
+  '澎湖縣',
+  '金門縣',
+  '連江縣',
+];
+
+const petTypeOptions = [
+  { value: '', label: '貓 / 狗' },
+  { value: '貓', label: '貓' },
+  { value: '狗', label: '狗' },
+];
+
+export default function SearchFormFields({
+  onSearchSubmit,
+  isModal = false,
+  initialValues = {},
+  hideModal,
+}) {
+  const [selectedService, setSelectedService] = useState(
+    initialValues.service || '日間托養'
+  );
+  const [selectedPetType, setSelectedPetType] = useState(
+    initialValues.petType || ''
+  );
+  const [selectedArea, setSelectedArea] = useState(initialValues.area || '');
+  const [dateRange, setDateRange] = useState(
+    initialValues.dates || [null, null]
+  );
+  const [startDate, endDate] = dateRange;
+
+  const petDropdownRef = useRef(null);
+  const petDropdownInstance = useRef(null);
+  const areaDropdownRef = useRef(null);
+  const areaDropdownInstance = useRef(null);
+
+  useEffect(() => {
+    // 建立實例
+    petDropdownInstance.current = new Dropdown(petDropdownRef.current, {
+      autoClose: 'outside',
+      boundary: 'clippingParents',
+    });
+    areaDropdownInstance.current = new Dropdown(areaDropdownRef.current);
+
+    // 返回 cleanup 函式來銷毀實例
+    return () => {
+      if (petDropdownInstance.current) petDropdownInstance.current.dispose();
+      if (areaDropdownInstance.current) areaDropdownInstance.current.dispose();
+    };
+  }, []);
+
+  const showPetDropdown = () => {
+    petDropdownInstance.current.toggle();
   };
 
-  const petCountText = () => {
-    if (catCount > 0 && dogCount > 0) return `${catCount}貓 / ${dogCount}狗`;
-    if (catCount > 0) return `${catCount}貓`;
-    if (dogCount > 0) return `${dogCount}狗`;
-    return '貓 / 狗';
+  const showAreaDropdown = () => {
+    areaDropdownInstance.current.toggle();
   };
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    const searchParams = {
+      service: selectedService,
+      petType: selectedPetType,
+      address: selectedArea,
+      dates: dateRange,
+    };
+    onSearchSubmit(searchParams);
+  };
+
+  const hasDateValue = startDate !== null;
 
   return (
-    <>
-      {/* --- Desktop Search Form --- */}
-      <div className="d-none d-md-block bg-light rounded-4 shadow-primary">
-        <div className="py-4 px-6">
-          <div className="row gx-4 align-items-end">
-            {/* Pet Selector */}
-            <div className="col">
-              <p className="text-gray-500 mb-2 small">您的寵物</p>
-              <div className="dropdown">
-                <button
-                  className="custom-dropdown-toggle w-100 d-flex justify-content-between align-items-center btn"
-                  type="button"
-                  data-bs-toggle="dropdown"
-                  data-bs-auto-close="outside"
-                  aria-expanded="false"
-                >
-                  <div className="d-flex align-items-center">
-                    <Image src="/assets/images/search-page/Pet-icon.svg" width={24} height={24} alt="pet-icon" className="me-2"/>
-                    <span data-petnum-show>{petCountText()}</span>
-                  </div>
-                  <ChevronDownIcon className="text-gray-500" style={{ width: '1.25rem', height: '1.25rem' }}/>
-                </button>
-                <ul className="dropdown-menu py-4 w-100">
-                  {/* Cat Counter */}
-                  <li>
-                    <div className="dropdown-item d-block py-2 px-4 mb-2 d-flex justify-content-between align-items-center">
-                      <span>貓</span>
-                      <div className="d-flex align-items-center">
-                        <button type="button" className="btn p-0" onClick={() => handlePetCount('cat', '-')}>
-                           <MinusCircleIcon className="fs-6 text-gray-800" style={{ width: '1.5rem', height: '1.5rem' }}/>
-                        </button>
-                        <span className="mx-3 text-gray-500">{catCount}</span>
-                        <button type="button" className="btn p-0" onClick={() => handlePetCount('cat', '+')}>
-                          <PlusCircleIcon className="fs-6 text-gray-500" style={{ width: '1.5rem', height: '1.5rem' }}/>
-                        </button>
-                      </div>
-                    </div>
+    <form
+      onSubmit={handleSubmit}
+      className={`${isModal ? '' : 'shadow-primary'} ${
+        styles.sitterSearchForm
+      }`}
+    >
+      <div className="row g-0">
+        {serviceTypes.map((service) => (
+          <div className="col-3" key={service.key}>
+            <button
+              type="button"
+              className={`btn rounded-0 w-100 d-flex flex-column justify-content-center align-items-center h-100 py-5 px-0 p-md-6 ${
+                styles.typeSelectBtn
+              } ${selectedService === service.key ? styles.active : ''}`}
+              onClick={() => setSelectedService(service.key)}
+            >
+              <Image
+                src={service.icon}
+                alt={`${service.text} icon`}
+                width={32}
+                height={32}
+                className="mb-4"
+              />
+              <h3 className="fs-9 fs-md-7">{service.text}</h3>
+            </button>
+          </div>
+        ))}
+      </div>
+      <div
+        className={`p-7 pt-md-5 ${isModal ? '' : 'border-top border-gray-800'}`}
+      >
+        <div
+          className={`row gx-4 ${
+            isModal ? 'gy-5 flex-column' : 'align-items-end'
+          }`}
+        >
+          <div className={`${isModal ? 'col-12' : 'col'}`}>
+            <label className="text-gray-500 mb-2 small d-block">您的寵物</label>
+            <div className="dropdown">
+              <button
+                ref={petDropdownRef}
+                className="form-control border-0 bg-gray-1000  text-start d-flex justify-content-between align-items-center py-4 px-5 rounded-3"
+                type="button"
+                data-bs-toggle="dropdown"
+                onClick={showPetDropdown}
+              >
+                <div className="d-flex align-items-center">
+                  <Image
+                    src="/search-page/Pet-icon.svg"
+                    width={24}
+                    height={24}
+                    alt="pet-icon"
+                    className="me-2"
+                  />
+                  <span>{selectedPetType || '貓 / 狗'}</span>
+                </div>
+                <ChevronDownIcon
+                  className="text-gray-500"
+                  style={{ width: '1.25rem', height: '1.25rem' }}
+                />
+              </button>
+              <ul className={`${styles.searchDropdownMenu} dropdown-menu w-100`}>
+                {petTypeOptions.map((opt) => (
+                  <li key={opt.value}>
+                    <button
+                      className="dropdown-item"
+                      type="button"
+                      onClick={() => setSelectedPetType(opt.value)}
+                    >
+                      {opt.label}
+                    </button>
                   </li>
-                  {/* Dog Counter */}
-                  <li>
-                    <div className="dropdown-item d-block py-2 px-4 mb-2 d-flex justify-content-between align-items-center">
-                      <span>狗</span>
-                      <div className="d-flex align-items-center">
-                         <button type="button" className="btn p-0" onClick={() => handlePetCount('dog', '-')}>
-                           <MinusCircleIcon className="fs-6 text-gray-800" style={{ width: '1.5rem', height: '1.5rem' }}/>
-                        </button>
-                        <span className="mx-3 text-gray-500">{dogCount}</span>
-                        <button type="button" className="btn p-0" onClick={() => handlePetCount('dog', '+')}>
-                          <PlusCircleIcon className="fs-6 text-gray-500" style={{ width: '1.5rem', height: '1.5rem' }}/>
-                        </button>
-                      </div>
-                    </div>
+                ))}
+              </ul>
+            </div>
+          </div>
+          <div className={`${isModal ? 'col-12' : 'col'}`}>
+            <label className="text-gray-500 mb-2 small d-block">您的地區</label>
+            <div className="dropdown">
+              <button
+                ref={areaDropdownRef}
+                className="form-control border-0 bg-gray-1000 text-start d-flex justify-content-between align-items-center py-4 px-5 rounded-3"
+                type="button"
+                onClick={showAreaDropdown}
+                data-bs-toggle="dropdown"
+              >
+                <div className="d-flex align-items-center">
+                  <MapPinIcon
+                    className={`me-2 text-gray-500 ${styles.inputIcon}`}
+                  />
+                  <span>{selectedArea || '選擇地區'}</span>
+                </div>
+                <ChevronDownIcon
+                  className="text-gray-500"
+                  style={{ width: '1.25rem', height: '1.25rem' }}
+                />
+              </button>
+              <ul
+                className={`dropdown-menu border-gray-700 mt-2 w-100 ${styles.searchDropdownMenu}`}
+              >
+                {taiwanCities.map((city) => (
+                  <li key={city}>
+                    <button
+                      className="dropdown-item"
+                      type="button"
+                      onClick={() => setSelectedArea(city)}
+                    >
+                      {city}
+                    </button>
                   </li>
-                </ul>
-              </div>
+                ))}
+              </ul>
             </div>
-            {/* Area Selector */}
-            <div className="col">
-                <p className="gray-500 mb-2 small">您的地區</p>
-                {/* 這裡應該換成一個真正的 React 地區選擇組件 */}
-                <input type="text" className="form-control" placeholder="地區" />
+          </div>
+          <div className={`${isModal ? 'col-12' : 'col'}`}>
+            <label className="text-gray-500 mb-2 small d-block">照顧期間</label>
+            <div className="position-relative">
+              {!hasDateValue && (
+                <CalendarDaysIcon
+                  className={`position-absolute top-50 translate-middle-y ms-5 text-gray-500 ${styles.inputIcon}`}
+                />
+              )}
+
+              <DatePicker
+                selectsRange={true}
+                startDate={startDate}
+                endDate={endDate}
+                onChange={(update) => setDateRange(update)}
+                isClearable={true}
+                placeholderText="       日期"
+                wrapperClassName="w-100"
+                className={`form-control ${styles.datePickerInput} w-100 border-0 bg-gray-1000 rounded-3 py-4 px-5`}
+                locale="zh-TW"
+                dateFormat="yyyy/MM/dd"
+                minDate={new Date()}
+              />
+              {!hasDateValue && (
+                <ChevronDownIcon
+                  className={`text-gray-500 position-absolute top-50 end-0 me-5 translate-middle-y ${styles.inputIcon}`}
+                />
+              )}
             </div>
-            {/* Date Selector */}
-            <div className="col">
-                <p className="gray-500 mb-2 small">照顧期間</p>
-                {/* 這裡應該換成一個真正的 React 日期選擇器組件 */}
-                <input type="text" className="form-control" placeholder="日期" />
-            </div>
-            <div className="col-auto"> {/* col-3 會太寬，col-auto 自適應 */}
-              <Link href="/sitters" className="btn btn-primary d-block w-100">
-                搜尋保母
-              </Link>
+          </div>
+          <div className={`${isModal ? 'col-12 mt-7' : 'col'}`}>
+            <div
+              className={
+                isModal ? 'border-top border-gray-800 pt-7 d-flex' : ''
+              }
+            >
+              <button
+                type="button"
+                className="d-md-none btn btn-outline-primary w-100 me-3"
+                onClick={hideModal}
+              >
+                取消
+              </button>
+              <button
+                type="submit"
+                className="btn btn-primary text-light w-100 py-4 px-5"
+              >
+                {isModal ? '搜尋' : '搜尋保母'}
+              </button>
             </div>
           </div>
         </div>
       </div>
-      
-      {/* --- Mobile Search Trigger --- */}
-      <div className="d-md-none p-3 rounded-4 bg-light d-flex align-items-center shadow-primary">
-        <a href="#" className="custom-dropdown-toggle d-block me-3 flex-grow-1" data-bs-toggle="modal" data-bs-target="#sitter-search-modal">
-          您的需求
-        </a>
-        <a href="#" className="btn btn-primary" data-bs-toggle="modal" data-bs-target="#sitter-search-modal">
-          搜尋
-        </a>
-      </div>
-
-      {/* --- Mobile Search Modal --- */}
-      <div className="modal fade sitter-search-modal" id="sitter-search-modal" tabIndex="-1" aria-hidden="true">
-        {/* Modal 內容與 Desktop 類似，只是垂直排列 */}
-        {/* ... 此處省略 Modal 內部結構，應將 Desktop 表單內容放入 Modal 中 ... */}
-      </div>
-    </>
+    </form>
   );
 }

--- a/app/ui/styles/_helper.scss
+++ b/app/ui/styles/_helper.scss
@@ -12,6 +12,10 @@
     background: linear-gradient(123.31deg, #a9bd7e 0%, #c7d6a5 100%);
   }
 
+.shadow-primary {
+    box-shadow: 0px 4px 80px 0px #F6844D66;
+  }
+
 @include media-breakpoint-up(md) {
   .dog-foot-title-md {
     position: relative;

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,10 @@
       "dependencies": {
         "@heroicons/react": "^2.2.0",
         "bootstrap": "^5.3.6",
+        "date-fns": "^4.1.0",
         "next": "15.3.2",
         "react": "^19.0.0",
+        "react-datepicker": "^8.4.0",
         "react-dom": "^19.0.0",
         "sass": "^1.89.0",
         "swiper": "^11.2.8"
@@ -179,6 +181,54 @@
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.1.tgz",
+      "integrity": "sha512-azI0DrjMMfIug/ExbBaeDVJXcY0a7EPvPjb2xAJPa4HeimBX+Z18HK8QQR3jb6356SnDDdxx+hinMLcJEDdOjw==",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.9"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.1.tgz",
+      "integrity": "sha512-cwsmW/zyw5ltYTUeeYJ60CnQuPqmGwuGVhG9w0PRaRKkAyi38BT5CKrpIbb+jtahSwUl04cWzSx9ZOIxeS6RsQ==",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.1",
+        "@floating-ui/utils": "^0.2.9"
+      }
+    },
+    "node_modules/@floating-ui/react": {
+      "version": "0.27.12",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.27.12.tgz",
+      "integrity": "sha512-kKlWNrpIQxF1B/a2MZvE0/uyKby4960yjO91W7nVyNKmmfNi62xU9HCjL1M1eWzx/LFj/VPSwJVbwQk9Pq/68A==",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.1.3",
+        "@floating-ui/utils": "^0.2.9",
+        "tabbable": "^6.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=17.0.0",
+        "react-dom": ">=17.0.0"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.3.tgz",
+      "integrity": "sha512-huMBfiU9UnQ2oBwIhgzyIiSpVgvlDstU8CX0AF+wS+KzmYMs0J2a3GwuFHV1Lz+jlrQGeC1fF+Nv0QoumyV0bA==",
+      "dependencies": {
+        "@floating-ui/dom": "^1.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.9.tgz",
+      "integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg=="
     },
     "node_modules/@heroicons/react": {
       "version": "2.2.0",
@@ -2105,6 +2155,14 @@
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
@@ -2273,6 +2331,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/debug": {
@@ -4754,6 +4821,20 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-datepicker": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/react-datepicker/-/react-datepicker-8.4.0.tgz",
+      "integrity": "sha512-6nPDnj8vektWCIOy9ArS3avus9Ndsyz5XgFCJ7nBxXASSpBdSL6lG9jzNNmViPOAOPh6T5oJyGaXuMirBLECag==",
+      "dependencies": {
+        "@floating-ui/react": "^0.27.3",
+        "clsx": "^2.1.1",
+        "date-fns": "^4.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17 || ^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^16.9.0 || ^17 || ^18 || ^19 || ^19.0.0-rc"
+      }
+    },
     "node_modules/react-dom": {
       "version": "19.1.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
@@ -5479,6 +5560,11 @@
       "engines": {
         "node": ">= 4.7.0"
       }
+    },
+    "node_modules/tabbable": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
+      "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew=="
     },
     "node_modules/tinyglobby": {
       "version": "0.2.13",

--- a/package.json
+++ b/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@heroicons/react": "^2.2.0",
     "bootstrap": "^5.3.6",
+    "date-fns": "^4.1.0",
     "next": "15.3.2",
     "react": "^19.0.0",
+    "react-datepicker": "^8.4.0",
     "react-dom": "^19.0.0",
     "sass": "^1.89.0",
     "swiper": "^11.2.8"


### PR DESCRIPTION
### 解決的問題 (What this PR does)

這個 PR 引入了網站核心的可重用搜尋元件 (`SitterSearch`)，包含了完整的 UI 結構和前端狀態管理。此元件可被應用於首頁和保母列表頁，並根據所在頁面執行不同的搜尋行為。

---

### 實現的細節 (Key Features Implemented)

* **響應式 UI:**
    * **桌面版:** 顯示完整的表單，包含服務類型選擇、寵物類型、地區和日期。
    * **手機版:** 顯示一個觸發按鈕，點擊後會彈出置中的 Modal 表單。
* **狀態管理:**
    * 使用 `useState` hook 管理所有表單欄位的狀態。
    * 整合 `react-datepicker` 來處理日期範圍選擇。
* **核心邏輯:**
    * 使用 `usePathname` 判斷當前頁面。
    * **首頁行為:** 提交表單後，將搜尋條件組合為 URL query string 並跳轉至 `/sitters` 頁面。
    * **列表頁行為:** 提交表單後，呼叫 `onSearch` prop，將 query string 回傳給父層處理，不刷新頁面。

---

### 待辦事項 (Remaining To-Do Items)

這個 PR **不包含** 以下功能的最終實現，這些將在後續的任務中完成：

- [ ] 完成列表頁的**排序元件**
- [ ] 優化列表頁的**分頁元件**
- [ ] 在搜尋執行時加上**Loading效果**
- [ ] 最終確認並優化與後端 API 對接的**搜尋篩選邏輯**

---

### 如何測試 (How to Test)

1. 在本機運行此分支 (`npm run dev`)。
2. **首頁測試:**
    - 前往首頁 (`/`)。
    - 填寫桌面版或手機版 Modal 中的搜尋表單。
    - 點擊「搜尋保母」。
    - **預期結果:** 頁面應成功跳轉至 `/sitters`，並且 URL 應包含您選擇的搜尋條件 (例如 `.../sitters?service=日間托養&area=台北市`)。
3. **列表頁測試:**
    - 前往保母列表頁 (`/sitters`)。
    - 填寫搜尋表單。
    - 點擊「搜尋保母」。
    - **預期結果:** 頁面不應刷新或跳轉。請打開開發者工具的 Console，確認父層的 `onSearch` 函式被呼叫，並印出了正確的 query string。
