### PR TITLE
feat(ui): Refactor Logo into a standalone TypeScript component

### DIFF
--- a/app/ui/common/Logo/Logo.tsx
+++ b/app/ui/common/Logo/Logo.tsx
@@ -1,0 +1,32 @@
+import Image from "next/image";
+import Link from "next/link";
+
+interface LogoProps{
+    className?: string;
+    onClick?: () => void;
+}
+
+export default function Logo({className, onClick}: LogoProps) {
+  return (
+    <>
+      <Link href="/" className={className} onClick={onClick}>
+        <Image
+          src="/layout/layout-header-logo.png"
+          alt="PetSitter Logo Desktop"
+          width={178}
+          height={48}
+          className="d-none d-lg-block"
+          priority
+        />
+        <Image
+          src="/layout/layout-header-logo-sm.png"
+          alt="PetSitter Logo Mobile"
+          width={140}
+          height={40}
+          className="d-lg-none"
+          priority
+        />
+      </Link>
+    </>
+  );
+}

--- a/app/ui/layouts/Header.jsx
+++ b/app/ui/layouts/Header.jsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import Image from 'next/image';
 import styles from './Header.module.scss';
 import { useTooltip } from '@/app/hooks/useBootstrap';
+import Logo from '../common/Logo/Logo';
 
 export default function Header() {
   useTooltip();
@@ -76,24 +77,7 @@ export default function Header() {
       id="navbar"
     >
       <div className={`${styles.headerContainer} container`}>
-        <Link href="/" className="navbar-brand">
-          <Image
-            src="/layout/layout-header-logo.png"
-            alt="PetSitter Logo Desktop"
-            width={178}
-            height={48}
-            className="d-none d-lg-block"
-            priority
-          />
-          <Image
-            src="/layout/layout-header-logo-sm.png"
-            alt="PetSitter Logo Mobile"
-            width={140}
-            height={40}
-            className="d-lg-none"
-            priority
-          />
-        </Link>
+        <Logo className="navbar-brand" />
 
         <button
           className="navbar-toggler border-0"
@@ -113,14 +97,7 @@ export default function Header() {
           aria-labelledby="offcanvasNavbarLabel"
         >
           <div className={`offcanvas-header p-4 ${styles.headerNavBgColor}`}>
-            <Link href="/" className="navbar-brand" onClick={handleLinkClick}>
-              <Image
-                src="/layout/layout-header-logo-sm.png"
-                alt="logo"
-                width={122}
-                height={27}
-              />
-            </Link>
+            <Logo className="navbar-brand" onClick={handleLinkClick} />
             <button
               type="button"
               className="btn-close text-reset"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pet-sitter-project-next",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pet-sitter-project-next",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "dependencies": {
         "@heroicons/react": "^2.2.0",
         "bootstrap": "^5.3.6",
@@ -20,8 +20,11 @@
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
+        "@types/node": "^24.1.0",
+        "@types/react": "^19.1.8",
         "eslint": "^9",
-        "eslint-config-next": "15.3.2"
+        "eslint-config-next": "15.3.2",
+        "typescript": "^5.8.3"
       }
     },
     "node_modules/@emnapi/core": {
@@ -1224,6 +1227,24 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
     },
+    "node_modules/@types/node": {
+      "version": "24.1.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.1.0.tgz",
+      "integrity": "sha512-ut5FthK5moxFKH2T1CUOC6ctR67rQRvvHdFLCD2Ql6KXmMuCrjsSsRI9UsLCm9M18BMwClv4pn327UvB7eeO1w==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~7.8.0"
+      }
+    },
+    "node_modules/@types/react": {
+      "version": "19.1.8",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.8.tgz",
+      "integrity": "sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==",
+      "dev": true,
+      "dependencies": {
+        "csstype": "^3.0.2"
+      }
+    },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.34.1",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.34.1.tgz",
@@ -2248,6 +2269,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "dev": true
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -5306,7 +5333,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5332,6 +5358,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
+      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
+      "dev": true
     },
     "node_modules/unrs-resolver": {
       "version": "1.9.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,10 @@
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",
+    "@types/node": "^24.1.0",
+    "@types/react": "^19.1.8",
     "eslint": "^9",
-    "eslint-config-next": "15.3.2"
+    "eslint-config-next": "15.3.2",
+    "typescript": "^5.8.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,12 +39,21 @@ importers:
       '@eslint/eslintrc':
         specifier: ^3
         version: 3.3.1
+      '@types/node':
+        specifier: ^24.1.0
+        version: 24.1.0
+      '@types/react':
+        specifier: ^19.1.8
+        version: 19.1.8
       eslint:
         specifier: ^9
         version: 9.26.0
       eslint-config-next:
         specifier: 15.3.2
         version: 15.3.2(eslint@9.26.0)(typescript@5.8.3)
+      typescript:
+        specifier: ^5.8.3
+        version: 5.8.3
 
 packages:
 
@@ -437,6 +446,12 @@ packages:
   '@types/json5@0.0.29':
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
 
+  '@types/node@24.1.0':
+    resolution: {integrity: sha512-ut5FthK5moxFKH2T1CUOC6ctR67rQRvvHdFLCD2Ql6KXmMuCrjsSsRI9UsLCm9M18BMwClv4pn327UvB7eeO1w==}
+
+  '@types/react@19.1.8':
+    resolution: {integrity: sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==}
+
   '@typescript-eslint/eslint-plugin@8.32.1':
     resolution: {integrity: sha512-6u6Plg9nP/J1GRpe/vcjjabo6Uc5YQPAMxsgQyGC/I0RuukiG1wIe3+Vtg3IrSCVJDmqK3j8adrtzXSENRtFgg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -752,6 +767,9 @@ packages:
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
+
+  csstype@3.1.3:
+    resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
 
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
@@ -1837,6 +1855,9 @@ packages:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
 
+  undici-types@7.8.0:
+    resolution: {integrity: sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==}
+
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
@@ -2223,6 +2244,14 @@ snapshots:
 
   '@types/json5@0.0.29': {}
 
+  '@types/node@24.1.0':
+    dependencies:
+      undici-types: 7.8.0
+
+  '@types/react@19.1.8':
+    dependencies:
+      csstype: 3.1.3
+
   '@typescript-eslint/eslint-plugin@8.32.1(@typescript-eslint/parser@8.32.1(eslint@9.26.0)(typescript@5.8.3))(eslint@9.26.0)(typescript@5.8.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
@@ -2569,6 +2598,8 @@ snapshots:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+
+  csstype@3.1.3: {}
 
   damerau-levenshtein@1.0.8: {}
 
@@ -3919,6 +3950,8 @@ snapshots:
       has-bigints: 1.1.0
       has-symbols: 1.1.0
       which-boxed-primitive: 1.1.1
+
+  undici-types@7.8.0: {}
 
   unpipe@1.0.0: {}
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,38 @@
+{
+  "compilerOptions": {
+    "paths": {
+      "@/*": ["./*"]
+    },
+    "target": "ES2017",
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "noEmit": true,
+    "incremental": true,
+    "module": "esnext",
+    "esModuleInterop": true,
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
+  },
+  "include": [
+    "next-env.d.ts",
+    ".next/types/**/*.ts",
+    "**/*.ts",
+    "**/*.tsx"
+, "app/(home)/page.jsx"  ],
+  "exclude": [
+    "node_modules"
+  ]
+}


### PR DESCRIPTION
# 這個 PR 做了什麼？
這個 PR 為專案引入了 TypeScript 開發環境，並執行了首次的元件重構，建立了一個可複用的 Logo 元件。

主要的成果包含：
- 環境設定: 安裝 typescript 及相關的型別定義檔，並完成 tsconfig.json 的配置（包含路徑別名）。
- 元件重構: 將 Header 元件中的 Logo 介面，抽離成一個獨立、型別化的新元件：app/ui/common/Logo/Logo.tsx。

# 為什麼需要這個變更？
- 提升程式碼品質: 旨在利用 TypeScript 的型別系統，在開發階段就能捕捉到潛在的錯誤，以提升專案的長期可維護性。
- 提升可維護性: 原本的 Logo 在 Header 元件中出現了兩次，造成程式碼重複且不易管理。將其重構為單一元件，解決了程式碼重複的問題，並遵循了 DRY (Don't Repeat Yourself) 原則。

# 主要的變更點
- 新增: tsconfig.json - TypeScript 的主要設定檔。
- 新增: app/ui/common/Logo/Logo.tsx - 全新的、可複用且型別化的 Logo 元件。
- 修改: app/ui/layouts/Header/Header.jsx - 將寫死的 Logo JSX 替換為新的 <Logo /> 元件。
- 修改: package.json & package-lock.json - 新增了 TypeScript 相關的開發依賴。

# 如何測試？
切換到此分支: git checkout feat/integrate-typescript

安裝依賴: npm install

啟動開發伺服器: npm run dev

在瀏覽器中打開應用程式，確認 Header 中的 Logo（包含主導覽列和手機版的側拉選單中）能夠正常顯示與運作，且外觀與功能和修改前完全一致。