### PR TITLE
feat(auth): Implement user authentication flow

### DIFF
--- a/app/(auth)/layout.tsx
+++ b/app/(auth)/layout.tsx
@@ -1,0 +1,29 @@
+import Logo from '../ui/common/Logo/Logo';
+
+export default function AuthLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="bg-gradient-light d-flex flex-column vh-100">
+      <header className="py-6">
+        <div className="text-center">
+          <Logo className="d-inline-block" />
+        </div>
+      </header>
+
+      <main className="container my-auto">
+        <div className="row justify-content-center">
+          <div className="col-lg-5 col-md-7 col-sm-9">
+            <div className="card shadow-lg border-0 rounded-lg">
+              <div className="card-body p-5">{children}</div>
+            </div>
+          </div>
+        </div>
+      </main>
+
+      <footer className="py-6"></footer>
+    </div>
+  );
+}

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -1,10 +1,34 @@
+'use client';
+
+import { useAuth } from '@/app/lib/contexts/AuthContext';
 import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
 
 export default function LoginPage() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  const { login, isLoading } = useAuth();
+  const router = useRouter();
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setError(null);
+
+    try {
+      await login(email, password);
+      router.push('/');
+    } catch (err: any) {
+      setError(err.message || '發生未知錯誤，請稍後再試');
+    }
+  };
+
   return (
     <>
       <h3 className="text-center fw-light my-4">登入 Pawfect</h3>
-      <form>
+      <form onSubmit={handleSubmit}>
         {/* Email */}
         <div className="mb-3">
           <label htmlFor="email" className="form-label">
@@ -16,6 +40,8 @@ export default function LoginPage() {
             id="email"
             placeholder="name@example.com"
             autoComplete="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
             required
           />
         </div>
@@ -31,14 +57,33 @@ export default function LoginPage() {
             id="password"
             placeholder="請輸入密碼"
             autoComplete="current-password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
             required
           />
         </div>
 
+        {error && <div className="alert alert-danger mt-3">{error}</div>}
+
         {/* Submit Button */}
         <div className="d-grid mt-4 mb-3">
-          <button type="submit" className="btn btn-primary">
-            登入
+          <button
+            type="submit"
+            className="btn btn-primary"
+            disabled={isLoading}
+          >
+            {isLoading ? (
+              <>
+                <span
+                  className="spinner-border spinner-border-sm"
+                  role="status"
+                  aria-hidden="true"
+                ></span>
+                <span className="ms-2">登入中...</span>
+              </>
+            ) : (
+              '登入'
+            )}
           </button>
         </div>
 

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -1,0 +1,54 @@
+import Link from 'next/link';
+
+export default function LoginPage() {
+  return (
+    <>
+      <h3 className="text-center fw-light my-4">登入 Pawfect</h3>
+      <form>
+        {/* Email */}
+        <div className="mb-3">
+          <label htmlFor="email" className="form-label">
+            電子郵件
+          </label>
+          <input
+            type="email"
+            className="form-control"
+            id="email"
+            placeholder="name@example.com"
+            autoComplete="email"
+            required
+          />
+        </div>
+
+        {/* Password */}
+        <div className="mb-3">
+          <label htmlFor="password" className="form-label">
+            密碼
+          </label>
+          <input
+            type="password"
+            className="form-control"
+            id="password"
+            placeholder="請輸入密碼"
+            autoComplete="current-password"
+            required
+          />
+        </div>
+
+        {/* Submit Button */}
+        <div className="d-grid mt-4 mb-3">
+          <button type="submit" className="btn btn-primary">
+            登入
+          </button>
+        </div>
+
+        {/* Link to Register */}
+        <div className="text-center">
+          <small>
+            還沒有帳號嗎？ <Link href="/register">立即註冊</Link>
+          </small>
+        </div>
+      </form>
+    </>
+  );
+}

--- a/app/(auth)/register/page.tsx
+++ b/app/(auth)/register/page.tsx
@@ -1,0 +1,71 @@
+// app/(auth)/register/page.tsx
+
+import Link from 'next/link';
+
+export default function RegisterPage() {
+  return (
+    <>
+      <h3 className="text-center fw-light my-4">註冊新帳號</h3>
+      <form>
+        {/* User Name */}
+        <div className="mb-3">
+          <label htmlFor="name" className="form-label">
+            您的名稱
+          </label>
+          <input
+            type="text"
+            className="form-control"
+            id="name"
+            placeholder="例如：陳小明"
+            autoComplete="name"
+            required
+          />
+        </div>
+
+        {/* Email */}
+        <div className="mb-3">
+          <label htmlFor="email" className="form-label">
+            電子郵件
+          </label>
+          <input
+            type="email"
+            className="form-control"
+            id="email"
+            placeholder="name@example.com"
+            autoComplete="email"
+            required
+          />
+        </div>
+
+        {/* Password */}
+        <div className="mb-3">
+          <label htmlFor="new-password" className="form-label">
+            密碼
+          </label>
+          <input
+            type="password"
+            className="form-control"
+            id="new-password"
+            placeholder="至少 8 個字元"
+            autoComplete="new-password"
+            required
+          />
+        </div>
+
+        {/* Submit Button */}
+        <div className="d-grid mt-4 mb-3">
+          <button type="submit" className="btn btn-primary">
+            註冊
+          </button>
+        </div>
+
+        {/* Link to Login */}
+        <div className="text-center">
+          <small>
+            已經有帳號了嗎？ <Link href="/login">前往登入</Link>
+          </small>
+        </div>
+      </form>
+    </>
+  );
+}

--- a/app/(auth)/register/page.tsx
+++ b/app/(auth)/register/page.tsx
@@ -1,12 +1,51 @@
-// app/(auth)/register/page.tsx
+'use client';
 
+import { useAuth } from '@/app/lib/contexts/AuthContext';
 import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { ChangeEvent, FormEvent, useState } from 'react';
 
 export default function RegisterPage() {
+  const [formData, setFormData] = useState({
+    name: '',
+    email: '',
+    password: '',
+  });
+  const [error, setError] = useState<string | null>(null);
+
+  const { register, isLoading } = useAuth();
+  const router = useRouter();
+
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setFormData((prev) => ({
+      ...prev,
+      [name]: value,
+    }));
+  };
+
+  const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setError(null);
+
+    if (formData.password.length < 8) {
+      setError('密碼長度不得少於 8 個字元');
+      return;
+    }
+
+    try {
+      await register(formData);
+      alert('註冊成功！將為您登入並導向首頁。');
+      router.push('/');
+    } catch (err: any) {
+      setError(err.message || '發生未知錯誤，請稍後再試');
+    }
+  };
+
   return (
     <>
       <h3 className="text-center fw-light my-4">註冊新帳號</h3>
-      <form>
+      <form onSubmit={handleSubmit}>
         {/* User Name */}
         <div className="mb-3">
           <label htmlFor="name" className="form-label">
@@ -16,8 +55,11 @@ export default function RegisterPage() {
             type="text"
             className="form-control"
             id="name"
+            name="name"
             placeholder="例如：陳小明"
             autoComplete="name"
+            value={formData.name}
+            onChange={handleChange}
             required
           />
         </div>
@@ -31,8 +73,11 @@ export default function RegisterPage() {
             type="email"
             className="form-control"
             id="email"
+            name="email"
             placeholder="name@example.com"
             autoComplete="email"
+            value={formData.email}
+            onChange={handleChange}
             required
           />
         </div>
@@ -46,16 +91,36 @@ export default function RegisterPage() {
             type="password"
             className="form-control"
             id="new-password"
+            name="password"
             placeholder="至少 8 個字元"
             autoComplete="new-password"
+            value={formData.password}
+            onChange={handleChange}
             required
           />
         </div>
 
+        {error && <div className="alert alert-danger mt-3">{error}</div>}
+
         {/* Submit Button */}
         <div className="d-grid mt-4 mb-3">
-          <button type="submit" className="btn btn-primary">
-            註冊
+          <button
+            type="submit"
+            className="btn btn-primary"
+            disabled={isLoading}
+          >
+            {isLoading ? (
+              <>
+                <span
+                  className="spinner-border spinner-border-sm"
+                  role="status"
+                  aria-hidden="true"
+                ></span>
+                <span className="ms-2">註冊登入中...</span>
+              </>
+            ) : (
+              '註冊'
+            )}
           </button>
         </div>
 

--- a/app/(home)/dashboard/page.tsx
+++ b/app/(home)/dashboard/page.tsx
@@ -1,0 +1,15 @@
+import ProtectedRoute from '@/app/components/auth/ProtectedRoute';
+
+export default function DashboardPage() {
+  return (
+    <ProtectedRoute>
+      <div className="container mt-5">
+        <h1 className="mb-4">會員儀表板</h1>
+        <div className="alert alert-success">
+          恭喜！你正在瀏覽一個受保護的頁面。
+        </div>
+        <p>這裡是只有登入會員才能看到的專屬內容。</p>
+      </div>
+    </ProtectedRoute>
+  );
+}

--- a/app/(home)/layout.jsx
+++ b/app/(home)/layout.jsx
@@ -1,23 +1,15 @@
-import '@/app/ui/global.scss';
-import { NotoSansTC } from '../ui/fonts';
 import Header from '../ui/layouts/Header';
 import Footer from '../ui/layouts/Footer';
 
-export const metadata = {
-  title: 'Pawfect',
-  description: 'Pet sitter search app',
-};
 
-export default function RootLayout({ children }) {
+export default function HomeLayout({ children }) {
   return (
-    <html lang="en">
-      <body className={`${NotoSansTC.className}`}>
-        <Header />
+    <>
+      <Header />
+      <main>
         {children}
-        <Footer />
-        <div id="modal-root"></div>
-        <div id="datepicker-portal-root"></div>
-      </body>
-    </html>
+      </main>
+      <Footer />
+    </>
   );
 }

--- a/app/components/auth/ProtectedRoute.tsx
+++ b/app/components/auth/ProtectedRoute.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { useAuth } from '@/app/lib/contexts/AuthContext';
+import { useRouter } from 'next/navigation';
+import { ReactNode, useEffect } from 'react';
+
+interface ProtectedRouteProps {
+  children: ReactNode;
+}
+
+export default function ProtectedRoute({ children }: ProtectedRouteProps) {
+  const { isAuthenticated, isLoading } = useAuth();
+  const route = useRouter();
+
+  useEffect(() => {
+    if (!isLoading && !isAuthenticated) {
+      route.push('/login');
+    }
+  }, [isLoading, isAuthenticated, route]);
+
+  if (isLoading) {
+    return (
+      <div className="d-flex justify-content-center align-items-center vh-100">
+        <div className="spinner-border" role="status">
+          <span className="visually-hidden">Loading...</span>
+        </div>
+      </div>
+    );
+  }
+
+  if (isAuthenticated) {
+    return <>{children}</>;
+  }
+
+  return null;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,24 @@
+import '@/app/ui/global.scss';
+import { NotoSansTC } from '@/app/ui/fonts';
+
+export const metadata = {
+  title: 'Pawfect - 你的寵物好夥伴',
+  description: '專業的寵物保姆媒合平台',
+};
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="zh-Hant">
+      <body className={`${NotoSansTC.className} antialiased`}>
+        {children}
+
+        <div id="modal-root"></div>
+        <div id="datepicker-portal-root"></div>
+      </body>
+    </html>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import '@/app/ui/global.scss';
 import { NotoSansTC } from '@/app/ui/fonts';
+import { AuthProvider } from './lib/contexts/AuthContext';
 
 export const metadata = {
   title: 'Pawfect - 你的寵物好夥伴',
@@ -14,7 +15,7 @@ export default function RootLayout({
   return (
     <html lang="zh-Hant">
       <body className={`${NotoSansTC.className} antialiased`}>
-        {children}
+        <AuthProvider>{children}</AuthProvider>
 
         <div id="modal-root"></div>
         <div id="datepicker-portal-root"></div>

--- a/app/lib/contexts/AuthContext.tsx
+++ b/app/lib/contexts/AuthContext.tsx
@@ -100,6 +100,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
 
   const [state, dispatch] = useReducer(authReducer, initialState);
 
+  // 元件首次掛載時執行，用於處理頁面刷新後的持續登入。
   useEffect(() => {
     const initializeAuth = () => {
       try {
@@ -192,6 +193,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
 
       localStorage.setItem('authToken', accessToken);
       localStorage.setItem('user', JSON.stringify(user));
+      // 註冊成功後，直接 dispatch LOGIN_SUCCESS，實現自動登入的 UX。
       dispatch({
         type: 'LOGIN_SUCCESS',
         payload: { user, token: accessToken },

--- a/app/lib/contexts/AuthContext.tsx
+++ b/app/lib/contexts/AuthContext.tsx
@@ -41,6 +41,7 @@ type Action =
   | { type: 'REGISTER_FAILURE' };
 
 interface AuthContextType extends State {
+  isAuthenticated: boolean;
   login: (email: string, password: string) => Promise<void>;
   logout: () => void;
   register: (payload: RegisterPayload) => Promise<void>;

--- a/app/lib/contexts/AuthContext.tsx
+++ b/app/lib/contexts/AuthContext.tsx
@@ -1,0 +1,228 @@
+'use client';
+
+import {
+  createContext,
+  ReactNode,
+  useContext,
+  useEffect,
+  useMemo,
+  useReducer,
+} from 'react';
+
+interface User {
+  id: number;
+  email: string;
+  name: string;
+  role: 'owner' | 'sitter';
+}
+
+interface RegisterPayload {
+  name: string;
+  email: string;
+  password: string;
+}
+
+interface State {
+  user: User | null;
+  isLoading: boolean;
+  token: string | null;
+}
+
+type Action =
+  | { type: 'LOGIN_START' }
+  | { type: 'LOGIN_SUCCESS'; payload: { user: User; token: string } }
+  | { type: 'LOGIN_FAILURE' }
+  | { type: 'LOGOUT' }
+  | {
+      type: 'INITIALIZE';
+      payload: { user: User | null; token: string | null };
+    }
+  | { type: 'REGISTER_START' }
+  | { type: 'REGISTER_FAILURE' };
+
+interface AuthContextType extends State {
+  login: (email: string, password: string) => Promise<void>;
+  logout: () => void;
+  register: (payload: RegisterPayload) => Promise<void>;
+}
+
+const authReducer = (state: State, action: Action): State => {
+  switch (action.type) {
+    case 'LOGIN_START':
+    case 'REGISTER_START':
+      return {
+        ...state,
+        isLoading: true,
+      };
+    case 'LOGIN_SUCCESS':
+      return {
+        ...state,
+        isLoading: false,
+        user: action.payload.user,
+        token: action.payload.token,
+      };
+    case 'LOGIN_FAILURE':
+    case 'REGISTER_FAILURE':
+      return {
+        ...state,
+        isLoading: false,
+        user: null,
+        token: null,
+      };
+    case 'LOGOUT':
+      return {
+        ...state,
+        user: null,
+        token: null,
+      };
+    case 'INITIALIZE':
+      return {
+        ...state,
+        isLoading: false,
+        user: action.payload.user,
+        token: action.payload.token,
+      };
+
+    default:
+      return state;
+  }
+};
+
+const AuthContext = createContext<AuthContextType | undefined>(undefined);
+
+export const AuthProvider = ({ children }: { children: ReactNode }) => {
+  const initialState: State = {
+    user: null,
+    isLoading: true,
+    token: null,
+  };
+
+  const [state, dispatch] = useReducer(authReducer, initialState);
+
+  useEffect(() => {
+    const initializeAuth = () => {
+      try {
+        const token = localStorage.getItem('authToken');
+        const userString = localStorage.getItem('user');
+
+        if (token && userString) {
+          const user = JSON.parse(userString);
+          dispatch({ type: 'INITIALIZE', payload: { user, token } });
+        } else {
+          localStorage.removeItem('authToken');
+          localStorage.removeItem('user');
+          dispatch({
+            type: 'INITIALIZE',
+            payload: { user: null, token: null },
+          });
+        }
+      } catch (error) {
+        console.error('初始化驗證失敗', error);
+        dispatch({ type: 'INITIALIZE', payload: { user: null, token: null } });
+      }
+    };
+    initializeAuth();
+  }, []);
+
+  const API_URL = process.env.NEXT_PUBLIC_API_URL;
+
+  const login = async (email: string, password: string) => {
+    dispatch({ type: 'LOGIN_START' });
+
+    try {
+      const response = await fetch(`${API_URL}login`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, password }),
+      });
+
+      const data = await response.json();
+
+      if (!response.ok) {
+        throw new Error(data.message || '登入時發生錯誤');
+      }
+
+      const { accessToken, user } = data;
+
+      localStorage.setItem('authToken', accessToken);
+      localStorage.setItem('user', JSON.stringify(user));
+      dispatch({
+        type: 'LOGIN_SUCCESS',
+        payload: { user, token: accessToken },
+      });
+    } catch (error) {
+      localStorage.removeItem('user');
+      localStorage.removeItem('authToken');
+      dispatch({ type: 'LOGIN_FAILURE' });
+      throw error;
+    }
+  };
+
+  const logout = () => {
+    localStorage.removeItem('authToken');
+    localStorage.removeItem('user');
+    dispatch({ type: 'LOGOUT' });
+  };
+
+  const register = async (payload: RegisterPayload) => {
+    dispatch({ type: 'REGISTER_START' });
+
+    try {
+      const dataToSend = {
+        ...payload,
+        role: 'owner',
+      };
+
+      const response = await fetch(`${API_URL}register`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(dataToSend),
+      });
+
+      const data = await response.json();
+
+      if (!response.ok) {
+        const errorMessage =
+          typeof data === 'string' ? data : data.message || '註冊時發生錯誤';
+        throw new Error(errorMessage);
+      }
+
+      const { accessToken, user } = data;
+
+      localStorage.setItem('authToken', accessToken);
+      localStorage.setItem('user', JSON.stringify(user));
+      dispatch({
+        type: 'LOGIN_SUCCESS',
+        payload: { user, token: accessToken },
+      });
+    } catch (error) {
+      localStorage.removeItem('user');
+      localStorage.removeItem('authToken');
+      dispatch({ type: 'REGISTER_FAILURE' });
+      throw error;
+    }
+  };
+
+  const value = useMemo(
+    () => ({
+      ...state,
+      isAuthenticated: !!state.user,
+      login,
+      logout,
+      register,
+    }),
+    [state]
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+};
+
+export const useAuth = () => {
+  const context = useContext(AuthContext);
+
+  if (context === undefined) {
+    throw new Error('useAuth must be used within an AuthProvider');
+  }
+
+  return context;
+};

--- a/app/ui/layouts/Footer.jsx
+++ b/app/ui/layouts/Footer.jsx
@@ -10,7 +10,7 @@ const navLinks = [
   { href: '/sitters', text: '搜尋保母' },
   { href: '/become-a-sitter', text: '成為保母', disabled: true },
   { href: '/#index-qna', text: '常見問題' },
-  { href: '/login', text: '登入註冊', disabled: true },
+  { href: '/login', text: '登入註冊' },
 ];
 
 // 社群連結資料

--- a/app/ui/layouts/Header.jsx
+++ b/app/ui/layouts/Header.jsx
@@ -6,12 +6,14 @@ import Image from 'next/image';
 import styles from './Header.module.scss';
 import { useTooltip } from '@/app/hooks/useBootstrap';
 import Logo from '../common/Logo/Logo';
+import { useRouter } from 'next/navigation';
 
 export default function Header() {
   useTooltip();
   const [hasScrolled, setHasScrolled] = useState(false);
   const offcanvasRef = useRef(null);
   const offcanvasInstanceRef = useRef(null);
+  const router = useRouter();
 
   useEffect(() => {
     const handleScroll = () => {
@@ -51,9 +53,16 @@ export default function Header() {
     };
   }, []);
 
-  const handleLinkClick = () => {
+  const handleLinkClick = (e, href) => {
+    e.preventDefault();
+
     if (offcanvasInstanceRef.current) {
       offcanvasInstanceRef.current.hide();
+      setTimeout(() => {
+        router.push(href);
+      }, 350); 
+    }else {
+      router.push(href);
     }
   };
 
@@ -136,7 +145,7 @@ export default function Header() {
                     <Link
                       href={link.href}
                       className="nav-link link-gray-100"
-                      onClick={handleLinkClick}
+                      onClick={(e) => {handleLinkClick(e, link.href)}}
                     >
                       {link.text}
                     </Link>
@@ -155,28 +164,26 @@ export default function Header() {
                 style={{ objectFit: 'contain' }}
               />
               <Link
-                href="#"
-                className="d-lg-none btn btn-outline-primary w-100 disabled"
+                href="/login"
+                className="d-lg-none btn btn-outline-primary w-100"
                 tabIndex="-1"
-                aria-disabled="true"
-                onClick={handleLinkClick}
+                onClick={(e) => handleLinkClick(e, '/login')}
               >
                 登入
               </Link>
               <Link
-                href="#"
-                className="d-none d-lg-block btn text-primary border-0 p-0 flex-shrink-0 me-6 disabled"
+                href="/login"
+                className="d-none d-lg-block btn text-primary border-0 p-0 flex-shrink-0 me-6"
                 tabIndex="-1"
-                aria-disabled="true"
+                onClick={(e) => handleLinkClick(e, '/login')}
               >
                 登入
               </Link>
               <Link
-                href="#"
-                className="btn btn-primary w-100 w-lg-auto text-white mb-4 mb-lg-0 disabled"
+                href="/register"
+                className="btn btn-primary w-100 w-lg-auto text-white mb-4 mb-lg-0"
                 tabIndex="-1"
-                aria-disabled="true"
-                onClick={handleLinkClick}
+                onClick={(e) => handleLinkClick(e, '/register')}
               >
                 註冊
               </Link>


### PR DESCRIPTION
### 解決了什麼問題？ (What problem does this solve?)
- 為應用程式建立了完整的使用者註冊、登入功能。
- 新增了路由保護機制，防止未登入使用者存取會員專屬頁面 (如 /dashboard)。

### 本次變更內容 (Changes in this PR)
- **核心架構**:
  - 新增 `AuthContext` 進行全域的身分驗證狀態管理 (`useReducer`, `useEffect` 持續登入)。
  - 新增 `useAuth` 自訂 Hook 方便取用狀態。
- **功能頁面**:
  - 新增 `(auth)` 路由群組與獨立版面。
  - 新增 `/login` 與 `/register` 頁面，並完成其互動邏輯。
- **路由保護**:
  - 新增 `<ProtectedRoute />` 元件，實現客戶端路由保護。
- **Bug 修復**:
  - 修復了 Header Offcanvas 選單在頁面跳轉時的生命週期衝突問題。

### 如何手動測試 (How to test)
1. 訪問 `/register` 頁面，註冊一個新帳號。
2. 應會自動登入並跳轉至首頁。
3. 因尚未實作登出，請清除localstorage內的資料模擬登出。
4. 訪問 `/login` 頁面，使用剛剛的帳號登入。
5. 登入成功後，嘗試訪問 `/dashboard`，應能成功看到頁面。
6. 登出後，再次嘗試訪問 `/dashboard`，應被重導向至 `/login`。

### 相關截圖 (Screenshots)
登入、註冊按鈕已連結相關頁面
<img width="1007" height="536" alt="image" src="https://github.com/user-attachments/assets/9863fe41-200a-49b1-be4f-8f1e4837fcc5" />
註冊頁面
<img width="784" height="665" alt="image" src="https://github.com/user-attachments/assets/906d5ec3-1679-4d90-aba5-0d11eb169863" />
登入頁面
<img width="625" height="645" alt="image" src="https://github.com/user-attachments/assets/822a5627-40e7-44a8-9f40-c0348dfd5d9e" />
如登入成功，進入dashboard後應看到頁面內容，否則會被重新導向登入頁面
<img width="607" height="215" alt="image" src="https://github.com/user-attachments/assets/abe2b80e-b2bf-4c4e-a413-65ff9eec4c94" />

