### PR TITLE
feat(header): make header dynamic based on auth state

### DIFF
--- a/app/ui/layouts/Header.jsx
+++ b/app/ui/layouts/Header.jsx
@@ -7,6 +7,7 @@ import styles from './Header.module.scss';
 import { useTooltip } from '@/app/hooks/useBootstrap';
 import Logo from '../common/Logo/Logo';
 import { useRouter } from 'next/navigation';
+import { useAuth } from '@/app/lib/contexts/AuthContext';
 
 export default function Header() {
   useTooltip();
@@ -14,6 +15,7 @@ export default function Header() {
   const offcanvasRef = useRef(null);
   const offcanvasInstanceRef = useRef(null);
   const router = useRouter();
+  const { isAuthenticated, user, logout } = useAuth();
 
   useEffect(() => {
     const handleScroll = () => {
@@ -60,8 +62,8 @@ export default function Header() {
       offcanvasInstanceRef.current.hide();
       setTimeout(() => {
         router.push(href);
-      }, 350); 
-    }else {
+      }, 350);
+    } else {
       router.push(href);
     }
   };
@@ -77,6 +79,46 @@ export default function Header() {
     { href: '/become-a-sitter', text: '成為保母', disabled: true },
     { href: '/#index-qna', text: '常見問題' },
   ];
+
+  const authLinks = (
+    <>
+      <Link
+        href="/login"
+        className="d-lg-none btn btn-outline-primary w-100"
+        tabIndex="-1"
+        onClick={(e) => handleLinkClick(e, '/login')}
+      >
+        登入
+      </Link>
+      <Link
+        href="/login"
+        className="d-none d-lg-block btn text-primary border-0 p-0 flex-shrink-0 me-6"
+        tabIndex="-1"
+        onClick={(e) => handleLinkClick(e, '/login')}
+      >
+        登入
+      </Link>
+      <Link
+        href="/register"
+        className="btn btn-primary w-100 w-lg-auto text-white mb-4 mb-lg-0"
+        tabIndex="-1"
+        onClick={(e) => handleLinkClick(e, '/register')}
+      >
+        註冊
+      </Link>
+    </>
+  );
+
+  const userProfiles = (
+    <>
+    <div className='d-flex align-items-center'>
+      <span className="navbar-text me-5">你好, {user?.name}</span>
+      <button className="btn btn-outline-primary" onClick={logout}>
+        登出
+      </button>
+    </div>
+    </>
+  );
 
   return (
     <nav
@@ -145,7 +187,9 @@ export default function Header() {
                     <Link
                       href={link.href}
                       className="nav-link link-gray-100"
-                      onClick={(e) => {handleLinkClick(e, link.href)}}
+                      onClick={(e) => {
+                        handleLinkClick(e, link.href);
+                      }}
                     >
                       {link.text}
                     </Link>
@@ -163,30 +207,7 @@ export default function Header() {
                 className="d-lg-none d-block mt-auto"
                 style={{ objectFit: 'contain' }}
               />
-              <Link
-                href="/login"
-                className="d-lg-none btn btn-outline-primary w-100"
-                tabIndex="-1"
-                onClick={(e) => handleLinkClick(e, '/login')}
-              >
-                登入
-              </Link>
-              <Link
-                href="/login"
-                className="d-none d-lg-block btn text-primary border-0 p-0 flex-shrink-0 me-6"
-                tabIndex="-1"
-                onClick={(e) => handleLinkClick(e, '/login')}
-              >
-                登入
-              </Link>
-              <Link
-                href="/register"
-                className="btn btn-primary w-100 w-lg-auto text-white mb-4 mb-lg-0"
-                tabIndex="-1"
-                onClick={(e) => handleLinkClick(e, '/register')}
-              >
-                註冊
-              </Link>
+              {isAuthenticated? userProfiles : authLinks}
             </div>
           </div>
         </div>


### PR DESCRIPTION
### 解決了什麼問題？ (What problem does this solve?)
- 讓網站 Header 能夠根據使用者的登入狀態，動態顯示對應的 UI（使用者資訊 vs. 登入/註冊按鈕）。
- 提升了使用者登入後的個人化體驗，並提供了方便的登出功能。

### 本次變更內容 (Changes in this PR)
- **`Header.tsx`**:
  - 引入 `useAuth` Hook 來訂閱全域認證狀態。
  - 使用條件渲染，根據 `isAuthenticated` 的值動態切換 UI。
  - 將「已登入」和「未登入」的 UI 區塊抽離為獨立的 JSX 變數 (`userProfile`, `authLinks`)，提升程式碼可讀性。
  - 為「登出」按鈕綁定 `logout` 函式。

### 如何手動測試 (How to test)
1. 在未登入狀態下，確認 Header 顯示「登入」和「註冊」按鈕。
2. 成功登入後，確認 Header 自動更新為顯示使用者名稱和「登出」按鈕。
3. 點擊「登出」按鈕，確認 Header 恢復為「登入」和「註冊」按鈕。
4. 在手機版響應式視圖下，打開 Offcanvas 選單，重複以上測試，確保兩種視圖下的 UI 也正常運作。