### PR TITLE
test(layouts): add unit tests for Header component auth states

### DIFF
--- a/app/lib/contexts/AuthContext.tsx
+++ b/app/lib/contexts/AuthContext.tsx
@@ -89,7 +89,7 @@ const authReducer = (state: State, action: Action): State => {
   }
 };
 
-const AuthContext = createContext<AuthContextType | undefined>(undefined);
+export const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
 export const AuthProvider = ({ children }: { children: ReactNode }) => {
   const initialState: State = {

--- a/app/ui/layouts/Header.test.jsx
+++ b/app/ui/layouts/Header.test.jsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import Header from './Header';
+import { AuthContext } from '@/app/lib/contexts/AuthContext';
+
+vi.mock('bootstrap', async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    Offcanvas: class MockOffcanvas {
+      constructor() {
+        
+      }
+      toggle = vi.fn();
+      dispose = vi.fn();
+    },
+  };
+});
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+  }),
+}));
+
+const renderWithMockAuth = (ui, { providerProps, ...renderOptions }) => {
+  return render(
+    <AuthContext.Provider value={providerProps}>{ui}</AuthContext.Provider>,
+    renderOptions
+  );
+};
+
+describe('Header Component', () => {
+  it('should display login and register buttons when not authenticated', () => {
+    const providerProps = {
+      isAuthenticated: false,
+      user: null,
+      isLoading: false,
+      login: vi.fn(),
+      logout: vi.fn(),
+      register: vi.fn(),
+    };
+
+    renderWithMockAuth(<Header />, { providerProps });
+
+    const loginLinks = screen.getAllByRole('link', { name: /登入/i });
+    expect(loginLinks.length).toBeGreaterThan(0);
+
+    expect(screen.getByRole('link', { name: /註冊/i })).toBeInTheDocument();
+
+    expect(
+      screen.queryByRole('button', { name: /登出/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it('should display user name and Logout button when authenticated', ()=>{
+    const providerProps = {
+      isAuthenticated: true,
+      user: { name: '測試使用者' }, 
+      isLoading: false,
+      login: vi.fn(),
+      logout: vi.fn(),
+      register: vi.fn(),
+    };
+
+    renderWithMockAuth(<Header />, { providerProps })
+
+    expect(screen.getByText(/你好, 測試使用者/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /登出/i })).toBeInTheDocument();
+
+    expect(screen.queryByRole('link', { name: /登入/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: /註冊/i })).not.toBeInTheDocument();
+  })
+});


### PR DESCRIPTION
### 🎯 目的 (Purpose)
為 `Header` 元件添加單元測試，以確保其根據使用者的登入狀態（`isAuthenticated`）能夠正確地渲染對應的 UI 元素。
本次任務的核心是學習並實作了在測試環境中如何**模擬 (Mock) React Context**，這對於測試依賴全域狀態的元件至關重要。

### ✨ 主要變更 (Key Changes)
* **新增測試檔案**: `app/ui/layouts/Header.test.jsx`
* **模擬 Context**: 建立了一個 `renderWithMockAuth` 輔助函式，用於在測試中注入一個可控的、假的 `AuthContext` value。
* **模擬副作用**: 透過 `vi.mock('bootstrap', ...)`，從模組層級 mock 了 Bootstrap JS，成功解決了 `Offcanvas` 元件在 `jsdom` 環境中初始化失敗的問題。
* **測試案例**:
    1.  **未登入狀態**: 驗證「登入」和「註冊」按鈕存在，而「登出」按鈕不存在。
    2.  **已登入狀態**: 驗證歡迎訊息和「登出」按鈕存在，而「登入」按鈕不存在。

### 🧪 如何測試 (How to Test)
1.  `pnpm install`
2.  `pnpm test`
3.  **預期結果:** 所有測試 (`Logo.test.tsx` 和 `Header.test.jsx`) 都應該成功通過。