### PR TITLE
feat(animations): 全站導入 Framer Motion 並新增多組載入動畫

### DIFF
--- a/app/(home)/page.jsx
+++ b/app/(home)/page.jsx
@@ -2,20 +2,17 @@ import styles from '@/app/ui/pages/home.module.scss';
 import Image from 'next/image';
 import Link from 'next/link';
 
-import {
-  FAQ_DATA,
-  SERVICE_PROCESS_DATA,
-} from '@/app/lib/placeholder-data';
+import { FAQ_DATA } from '@/app/lib/placeholder-data';
 
 import TestimonialsSlider from '../ui/components/TestimonialsSlider';
 import React from 'react';
 import FaqAccordion from '../ui/components/FaqAccordion';
 import SitterSearch from '../ui/components/SitterSearch';
 import ServiceSection from '../ui/components/ServiceSection';
+import OrderProcessSection from '../ui/components/OrderProcessSection';
 
 // 資料引入
 const faqData = FAQ_DATA;
-const processData = SERVICE_PROCESS_DATA;
 
 export default function HomePage() {
   return (
@@ -52,79 +49,7 @@ export default function HomePage() {
         <TestimonialsSlider />
 
         {/* --- Order Process Section --- */}
-        <section className={`bg-gradient-light pt-12 pb-14 pt-lg-30 pb-lg-40`}>
-          <div className="container">
-            <h2 className="text-center text-primary fs-5 fs-md-3 d-flex align-items-center justify-content-center mb-1 mb-md-2">
-              <span className="pe-md-7 pe-2 fs-6">\</span>
-              <span className="text-center fw-bold">最 Pawfect 的預訂體驗</span>
-              <span className="ps-md-7 ps-2 fs-6">/</span>
-            </h2>
-            <p className="text-center fs-9 fs-md-7 text-gray-300 mb-9 mb-md-21">
-              預定流程直覺好上手
-            </p>
-            <div className="d-flex flex-column flex-lg-row justify-content-center align-items-center">
-              {processData.map((card, index) => (
-                <React.Fragment key={card.order}>
-                  <div
-                    className={`${styles.orderProcessCard} bg-light px-6 pt-5 pb-7 h-100`}
-                  >
-                    <div className="d-flex flex-md-column align-items-center justify-content-between mb-md-4">
-                      <p
-                        className={`${styles.cardOrder} text-center mb-md-4 ${card.colorClass}`}
-                      >
-                        {card.order}
-                      </p>
-                      <div className={`${styles.cardIcon}`}>
-                        <Image
-                          src={card.icon}
-                          className="card-img-top img-fluid"
-                          alt={`${card.title} Icon`}
-                          width={140}
-                          height={100}
-                          style={{ objectFit: 'contain' }}
-                        />
-                      </div>
-                    </div>
-                    <div className="d-flex flex-column align-items-md-center">
-                      <h4 className="card-title fs-md-6 fs-7 mb-4">
-                        {card.title}
-                      </h4>
-                      <p className="card-text text-start text-lg-center">
-                        {card.description}
-                      </p>
-                    </div>
-                  </div>
-
-                  {index < processData.length - 1 && (
-                    <>
-                      <Image
-                        src={
-                          index % 2 === 0 ? '/dogPrint.png' : '/dogPrint2.png'
-                        }
-                        alt="裝飾性圖標"
-                        width={75}
-                        height={109}
-                        className={`${styles.decorativeIcon1} d-none mx-5 d-lg-block`}
-                      />
-
-                      <div className="d-flex d-lg-none justify-content-center align-items-center my-4">
-                        <Image
-                          src={
-                            index % 2 === 0 ? '/dogPrint.png' : '/dogPrint2.png'
-                          }
-                          alt="裝飾性圖標"
-                          width={52}
-                          height={75}
-                          className={styles.decorativeIcon2}
-                        />
-                      </div>
-                    </>
-                  )}
-                </React.Fragment>
-              ))}
-            </div>
-          </div>
-        </section>
+        <OrderProcessSection />
 
         {/* --- FAQ Section --- */}
         <section className={styles.qnaCatDeco} id="index-qna">

--- a/app/(home)/page.jsx
+++ b/app/(home)/page.jsx
@@ -1,11 +1,9 @@
 import styles from '@/app/ui/pages/home.module.scss';
-
 import Image from 'next/image';
 import Link from 'next/link';
 
 import {
   FAQ_DATA,
-  SERVICES_DATA,
   SERVICE_PROCESS_DATA,
 } from '@/app/lib/placeholder-data';
 
@@ -13,9 +11,9 @@ import TestimonialsSlider from '../ui/components/TestimonialsSlider';
 import React from 'react';
 import FaqAccordion from '../ui/components/FaqAccordion';
 import SitterSearch from '../ui/components/SitterSearch';
+import ServiceSection from '../ui/components/ServiceSection';
 
 // 資料引入
-const servicesData = SERVICES_DATA;
 const faqData = FAQ_DATA;
 const processData = SERVICE_PROCESS_DATA;
 
@@ -48,56 +46,7 @@ export default function HomePage() {
         </section>
 
         {/* --- Services Section --- */}
-        <section className={`bg-gradient-light pt-17 pb-13 pt-md-42 pb-md-31`}>
-          <h2 className="text-center text-primary fs-5 fs-md-3 d-md-block d-none d-flex align-items-center justify-content-center mb-21">
-            <span className="pe-6 fs-6">\</span>
-            <span className="text-center fw-bold">
-              最 Pawfect 的寵物保母服務
-            </span>
-            <span className="ps-6 fs-6">/</span>
-          </h2>
-          <h2 className="text-center text-primary fs-5 d-md-none d-block d-flex align-items-center justify-content-center mb-9">
-            <span className="pe-4 fs-6">\</span>
-            <div className="text-center">
-              <span className="d-block fw-bold">最 Pawfect 的</span>
-              <span className="d-block fw-bold">寵物保母服務</span>
-            </div>
-            <span className="ps-4 fs-6">/</span>
-          </h2>
-          <div className="container">
-            <div className="row justify-content-center">
-              {servicesData.map((service, index) => (
-                <div className={`col-md-10 mb-9 mb-md-17`} key={index}>
-                  <div
-                    className={`row justify-content-md-around ${
-                      service.reverse ? 'flex-md-row-reverse' : ''
-                    }`}
-                  >
-                    <div
-                      className={`col-md-5 justify-content-md-start ${styles.serviceImg}`}
-                    >
-                      <Image
-                        src={service.img}
-                        alt={`${service.title}照片`}
-                        width={500}
-                        height={350}
-                        style={{ objectFit: 'contain' }}
-                      />
-                    </div>
-                    <div className={`col-md-6 ${styles.serviceLead}`}>
-                      <div>
-                        <h3>{service.title}</h3>
-                        <p className="text-center text-md-start">
-                          {service.description}
-                        </p>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              ))}
-            </div>
-          </div>
-        </section>
+        <ServiceSection />
 
         {/* --- Testimonials Section --- */}
         <TestimonialsSlider />

--- a/app/(home)/sitters/SittersPageClient.jsx
+++ b/app/(home)/sitters/SittersPageClient.jsx
@@ -356,7 +356,8 @@ export default function SittersPageClient() {
                 className="row row-cols-1 row-cols-md-2 row-cols-lg-4 gy-7 gy-md-11 mb-9 mb-lg-13"
                 variants={containerVariants}
                 initial="hidden"
-                animate="visible"
+                whileInView="visible"
+                viewport={{ once: true, amount: 0.2 }}
               >
                 {currentDisplaySitters.map((sitter) => (
                   <motion.div

--- a/app/(home)/sitters/SittersPageClient.jsx
+++ b/app/(home)/sitters/SittersPageClient.jsx
@@ -8,6 +8,8 @@ import { StarIcon, MapPinIcon, UserIcon } from '@heroicons/react/16/solid';
 
 import SitterSearch from '@/app/ui/components/SitterSearch';
 import { ChevronDownIcon } from '@heroicons/react/20/solid';
+import { motion } from 'framer-motion';
+import { containerVariants, cardVariants } from '@/app/lib/animations';
 
 const ITEMS_PER_PAGE = 8;
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL;
@@ -350,11 +352,17 @@ export default function SittersPageClient() {
             ) : error ? (
               <div className="alert alert-danger">{error}</div>
             ) : currentDisplaySitters.length > 0 ? (
-              <div className="row row-cols-1 row-cols-md-2 row-cols-lg-4 gy-7 gy-md-11 mb-9 mb-lg-13">
+              <motion.div
+                className="row row-cols-1 row-cols-md-2 row-cols-lg-4 gy-7 gy-md-11 mb-9 mb-lg-13"
+                variants={containerVariants}
+                initial="hidden"
+                animate="visible"
+              >
                 {currentDisplaySitters.map((sitter) => (
-                  <div
+                  <motion.div
                     className="col d-flex flex-column flex-md-row"
                     key={sitter.id}
+                    variants={cardVariants}
                   >
                     <div className="card bg-transparent border-0">
                       <img
@@ -423,9 +431,9 @@ export default function SittersPageClient() {
                         </Link>
                       </div>
                     </div>
-                  </div>
+                  </motion.div>
                 ))}
-              </div>
+              </motion.div>
             ) : (
               <p className="text-center text-muted py-5">
                 找不到符合條件的保姆。

--- a/app/lib/animations.js
+++ b/app/lib/animations.js
@@ -22,3 +22,16 @@ export const cardVariants = {
     },
   },
 };
+
+// 裝飾性小圖示用
+export const iconVariants = {
+  hidden: { scale: 0 },
+  visible: {
+    scale: 1,
+    transition: {
+      type: 'spring',
+      stiffness: 260,
+      damping: 20,
+    },
+  },
+};

--- a/app/lib/animations.js
+++ b/app/lib/animations.js
@@ -1,0 +1,24 @@
+
+// 外層容器用
+export const containerVariants = {
+  hidden: { opacity: 0 },
+  visible: {
+    opacity: 1,
+    transition: {
+      staggerChildren: 0.1, // 讓子元件一個接一個出現，每個間隔 0.1 秒
+    },
+  },
+};
+
+// 獨立卡片用
+export const cardVariants = {
+  hidden: { y: 20, opacity: 0 },
+  visible: {
+    y: 0,
+    opacity: 1,
+    transition: {
+      type: 'spring', // 使用彈簧動畫
+      stiffness: 100,
+    },
+  },
+};

--- a/app/ui/components/OrderProcessSection.jsx
+++ b/app/ui/components/OrderProcessSection.jsx
@@ -1,0 +1,129 @@
+'use client';
+import styles from '@/app/ui/pages/home.module.scss';
+import Image from 'next/image';
+
+import { SERVICE_PROCESS_DATA } from '@/app/lib/placeholder-data';
+
+import React from 'react';
+import { motion } from 'framer-motion';
+import {
+  containerVariants,
+  cardVariants,
+  iconVariants,
+} from '@/app/lib/animations';
+
+// 資料引入
+const processData = SERVICE_PROCESS_DATA;
+
+export default function OrderProcessSection() {
+  return (
+    <>
+      <section className={`bg-gradient-light pt-12 pb-14 pt-lg-30 pb-lg-40`}>
+        <div className="container">
+          <motion.div
+            initial="hidden"
+            whileInView="visible"
+            viewport={{ once: true, amount: 0.2 }}
+            variants={containerVariants}
+          >
+            <motion.h2
+              variants={cardVariants}
+              className="text-center text-primary fs-5 fs-md-3 d-flex align-items-center justify-content-center mb-1 mb-md-2"
+            >
+              <span className="pe-md-7 pe-2 fs-6">\</span>
+              <span className="text-center fw-bold">最 Pawfect 的預訂體驗</span>
+              <span className="ps-md-7 ps-2 fs-6">/</span>
+            </motion.h2>
+            <motion.p
+              variants={cardVariants}
+              className="text-center fs-9 fs-md-7 text-gray-300 mb-9 mb-md-21"
+            >
+              預定流程直覺好上手
+            </motion.p>
+            <div className="d-flex flex-column flex-lg-row justify-content-center align-items-center">
+              {processData.map((card, index) => (
+                <React.Fragment key={card.order}>
+                  <motion.div
+                    className={`${styles.orderProcessCard} bg-light px-6 pt-5 pb-7 h-100`}
+                    initial="hidden"
+                    whileInView="visible"
+                    viewport={{ once: true, amount: 0.3 }}
+                    variants={cardVariants}
+                  >
+                    <div className="d-flex flex-md-column align-items-center justify-content-between mb-md-4">
+                      <p
+                        className={`${styles.cardOrder} text-center mb-md-4 ${card.colorClass}`}
+                      >
+                        {card.order}
+                      </p>
+                      <div className={`${styles.cardIcon}`}>
+                        <Image
+                          src={card.icon}
+                          className="card-img-top img-fluid"
+                          alt={`${card.title} Icon`}
+                          width={140}
+                          height={100}
+                          style={{ objectFit: 'contain' }}
+                        />
+                      </div>
+                    </div>
+                    <div className="d-flex flex-column align-items-md-center">
+                      <h4 className="card-title fs-md-6 fs-7 mb-4">
+                        {card.title}
+                      </h4>
+                      <p className="card-text text-start text-lg-center">
+                        {card.description}
+                      </p>
+                    </div>
+                  </motion.div>
+
+                  {index < processData.length - 1 && (
+                    <>
+                      <motion.div
+                        initial="hidden"
+                        whileInView="visible"
+                        viewport={{ once: true }}
+                        variants={iconVariants}
+                        className={`${styles.decorativeIcon1} d-none d-lg-block mx-5 flex-shrink-0`}
+                      >
+                        <Image
+                          src={
+                            index % 2 === 0 ? '/dogPrint.png' : '/dogPrint2.png'
+                          }
+                          alt="裝飾性圖標"
+                          width={75}
+                          height={109}
+                        />
+                      </motion.div>
+
+                      <motion.div
+                        initial="hidden"
+                        whileInView="visible"
+                        viewport={{ once: true, amount: 0.5 }}
+                        variants={iconVariants}
+                        className={`d-flex d-lg-none justify-content-center align-items-center my-4`}
+                      >
+                        <div className={styles.decorativeIcon2}>
+                          <Image
+                            src={
+                              index % 2 === 0
+                                ? '/dogPrint.png'
+                                : '/dogPrint2.png'
+                            }
+                            alt="裝飾性圖標"
+                            width={52}
+                            height={75}
+                          />
+                        </div>
+                      </motion.div>
+                    </>
+                  )}
+                </React.Fragment>
+              ))}
+            </div>
+          </motion.div>
+        </div>
+      </section>
+    </>
+  );
+}

--- a/app/ui/components/ServiceSection.jsx
+++ b/app/ui/components/ServiceSection.jsx
@@ -1,0 +1,71 @@
+'use client';
+import styles from '@/app/ui/pages/home.module.scss';
+import Image from 'next/image';
+import { SERVICES_DATA } from '@/app/lib/placeholder-data';
+import { motion } from 'framer-motion';
+import { containerVariants, cardVariants } from '@/app/lib/animations';
+
+// 資料引入
+const servicesData = SERVICES_DATA;
+
+export default function ServiceSection() {
+  return (
+    <>
+      <section className={`bg-gradient-light pt-17 pb-13 pt-md-42 pb-md-31`}>
+        <h2 className="text-center text-primary fs-5 fs-md-3 d-md-block d-none d-flex align-items-center justify-content-center mb-21">
+          <span className="pe-6 fs-6">\</span>
+          <span className="text-center fw-bold">最 Pawfect 的寵物保母服務</span>
+          <span className="ps-6 fs-6">/</span>
+        </h2>
+        <h2 className="text-center text-primary fs-5 d-md-none d-block d-flex align-items-center justify-content-center mb-9">
+          <span className="pe-4 fs-6">\</span>
+          <div className="text-center">
+            <span className="d-block fw-bold">最 Pawfect 的</span>
+            <span className="d-block fw-bold">寵物保母服務</span>
+          </div>
+          <span className="ps-4 fs-6">/</span>
+        </h2>
+        <div className="container">
+          <div className="row justify-content-center">
+            {servicesData.map((service, index) => (
+              <motion.div
+                className={`col-md-10 mb-9 mb-md-17`}
+                key={index}
+                variants={cardVariants}
+                initial="hidden"
+                whileInView="visible"
+                viewport={{ once: true, amount: 0.2 }}
+              >
+                <div
+                  className={`row justify-content-md-around ${
+                    service.reverse ? 'flex-md-row-reverse' : ''
+                  }`}
+                >
+                  <div
+                    className={`col-md-5 justify-content-md-start ${styles.serviceImg}`}
+                  >
+                    <Image
+                      src={service.img}
+                      alt={`${service.title}照片`}
+                      width={500}
+                      height={350}
+                      style={{ objectFit: 'contain' }}
+                    />
+                  </div>
+                  <div className={`col-md-6 ${styles.serviceLead}`}>
+                    <div>
+                      <h3>{service.title}</h3>
+                      <p className="text-center text-md-start">
+                        {service.description}
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </motion.div>
+            ))}
+          </div>
+        </div>
+      </section>
+    </>
+  );
+}

--- a/app/ui/pages/home.module.scss
+++ b/app/ui/pages/home.module.scss
@@ -106,22 +106,14 @@
 }
 
 .decorativeIcon1 {
-  transition: transform 0.3s;
   box-sizing: border-box;
-  display: block;
   width: 75px;
   height: 109px;
-  &:hover {
-    transform: rotate(120deg);
-  }
 }
 
 .decorativeIcon2 {
   transform: rotate(90deg);
   transition: transform 0.3s;
-  &:hover {
-    transform: rotate(15deg);
-  }
 }
 
 /* --- FAQ Section --- */

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@heroicons/react": "^2.2.0",
     "bootstrap": "^5.3.6",
     "date-fns": "^4.1.0",
+    "framer-motion": "^12.23.12",
     "next": "15.3.2",
     "react": "^19.0.0",
     "react-datepicker": "^8.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0
+      framer-motion:
+        specifier: ^12.23.12
+        version: 12.23.12(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       next:
         specifier: 15.3.2
         version: 15.3.2(@babel/core@7.28.3)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.89.0)
@@ -1711,6 +1714,20 @@ packages:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
     engines: {node: '>= 0.6'}
 
+  framer-motion@12.23.12:
+    resolution: {integrity: sha512-6e78rdVtnBvlEVgu6eFEAgG9v3wLnYEboM8I5O5EXvfKC8gxGQB8wXJdhkMy10iVcn05jl6CNw7/HTsTCfwcWg==}
+    peerDependencies:
+      '@emotion/is-prop-valid': '*'
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
   fresh@2.0.0:
     resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
     engines: {node: '>= 0.8'}
@@ -2102,6 +2119,12 @@ packages:
 
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  motion-dom@12.23.12:
+    resolution: {integrity: sha512-RcR4fvMCTESQBD/uKQe49D5RUeDOokkGRmz4ceaJKDBgHYtZtntC/s2vLvY38gqGaytinij/yi3hMcWVcEF5Kw==}
+
+  motion-utils@12.23.6:
+    resolution: {integrity: sha512-eAWoPgr4eFEOFfg2WjIsMoqJTW6Z8MTUCgn/GZ3VRpClWBdnbjryiA3ZSNLyxCTmCQx4RmYX6jX1iWHbenUPNQ==}
 
   mrmime@2.0.1:
     resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
@@ -4583,6 +4606,15 @@ snapshots:
 
   forwarded@0.2.0: {}
 
+  framer-motion@12.23.12(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+    dependencies:
+      motion-dom: 12.23.12
+      motion-utils: 12.23.6
+      tslib: 2.8.1
+    optionalDependencies:
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+
   fresh@2.0.0: {}
 
   fsevents@2.3.3:
@@ -4983,6 +5015,12 @@ snapshots:
       brace-expansion: 2.0.1
 
   minimist@1.2.8: {}
+
+  motion-dom@12.23.12:
+    dependencies:
+      motion-utils: 12.23.6
+
+  motion-utils@12.23.6: {}
 
   mrmime@2.0.1: {}
 


### PR DESCRIPTION
### 專案目標 (Goal)

本次更新旨在為專案引入 `framer-motion` 動畫函式庫，並為核心頁面（保姆列表、首頁）增加精緻的「進入可視區域 (in-view)」載入動畫，以提升整體的視覺質感與使用者體驗。

### 主要變更 (Key Changes)

-   **新增依賴**：將 `framer-motion` 加入專案。
-   **建立共用動畫庫**：在 `app/lib/animations.js` 中建立了可重用的動畫變體 (variants)，包含 `containerVariants`, `cardVariants`, `iconVariants`，方便未來擴展與統一管理。
-   **保姆列表頁 (`/sitters`)**：為保姆卡片列表實現了 `staggerChildren` 交錯載入動畫。
-   **首頁 (`/`)**：
    -   將「服務介紹」與「預訂體驗」區塊重構為獨立的客戶端元件 (`ServiceSection`, `OrderProcessSection`)，以解決伺服器元件無法執行客戶端動畫的問題。
    -   為上述兩個區塊的所有卡片和圖示，都實現了 `whileInView` 滾動觸發動畫。
    -   為「預訂體驗」區塊設計並實現了標題、卡片、裝飾圖示的組合式動畫。

### 技術亮點與問題解決 (Technical Highlights & Problem Solving)

在開發過程中，解決了數個關鍵的技術挑戰：

1.  **Turbopack 環境問題**：透過清理 `.next` 快取與 `node_modules`，解決了因工具鏈快取不一致導致的 `Module not found` 錯誤。
2.  **`next/image` 佈局難題**：
    -   透過在 Flex Item 上使用 `flex-shrink-0`，解決了因 Flexbox 自動縮放機制導致的圖示寬度被壓縮問題。
    -   採用 `fill` 屬性搭配 `position-relative` 父層，取代傳統的 `width/height` + `style`，實現了 `next/image` 在 `motion.div` 容器中的可靠填充。
3.  **CSS `transform` 衝突**：利用巢狀 `div` 結構，成功分離了手機版圖示上**靜態的 CSS `rotate` 樣式**與**動態的 Framer Motion `scale` 動畫**對 `transform` 屬性的控制權，避免了樣式覆蓋。

### 成果展示 (Result)

使用者現在瀏覽保姆列表與首頁時，會看到流暢、有互動感的進場動畫，大幅提升了網站的現代感與專業度。

---
**待辦事項 (Checklist)**
- [x] 功能已在本地端測試完成
- [x] 動畫在桌面與手機版皆能正常顯示
- [x] 已將相關邏輯封裝至獨立元件